### PR TITLE
Add a require on launchy

### DIFF
--- a/lib/letter_opener.rb
+++ b/lib/letter_opener.rb
@@ -1,6 +1,7 @@
 require "fileutils"
 require "digest/sha1"
 require "cgi"
+require "launchy"
 
 require "letter_opener/message"
 require "letter_opener/delivery_method"


### PR DESCRIPTION
Hi, I've added a missing require on launchy to avoid `NameError (uninitialized constant LetterOpener::DeliveryMethod::Launchy)` when launchy has not already been loaded.
