### PR TITLE
Set the charset in email preview

### DIFF
--- a/lib/letter_opener/message.html.erb
+++ b/lib/letter_opener/message.html.erb
@@ -1,3 +1,5 @@
+<meta http-equiv="Content-Type" content="text/html; charset=<%= encoding %>">
+
 <style type="text/css">
   #message_headers {
     position: absolute;

--- a/lib/letter_opener/message.rb
+++ b/lib/letter_opener/message.rb
@@ -28,11 +28,15 @@ module LetterOpener
     end
 
     def body
-      (@part && @part.body || @mail.body).to_s
+      @body ||= (@part && @part.body || @mail.body).to_s
     end
 
     def type
       content_type =~ /html/ ? "rich" : "plain"
+    end
+
+    def encoding
+      body.respond_to?(:encoding) ? body.encoding : "utf-8"
     end
   end
 end


### PR DESCRIPTION
I've also added a `<meta>` tag to set the charset in the email preview so accents are properly displayed.
