### PR TITLE
Fixed that message headers overflows message body

### DIFF
--- a/lib/letter_opener/message.html.erb
+++ b/lib/letter_opener/message.html.erb
@@ -2,7 +2,7 @@
 
 <style type="text/css">
   #message_headers {
-    position: absolute;
+    position: static;
     top: 0px;
     left: 0;
     width: 100%;


### PR DESCRIPTION
Apparently, in some projects message headers can overflow top-part of the rich message body. Tested in Chrome 13, FireFox 6 and Safari 5.
