### PR TITLE
Preventing body from being hidden by using specifying body margin-top as !important

### DIFF
--- a/lib/letter_opener/message.html.erb
+++ b/lib/letter_opener/message.html.erb
@@ -51,7 +51,7 @@
   }
 
   body {
-    margin-top: 96px;
+    margin-top: 96px !important;
   }
 </style>
 


### PR DESCRIPTION
Use !important declaration in body margin-top to override inline CSS styles on body tag
