### PR TITLE
Fix for deliver! error

### DIFF
--- a/lib/letter_opener/delivery_method.rb
+++ b/lib/letter_opener/delivery_method.rb
@@ -1,11 +1,13 @@
 module LetterOpener
   class DeliveryMethod
     def initialize(options = {})
-      @options = {:location => './letter_opener'}.merge!(options)
+      self.settings = {:location => './letter_opener'}.merge!(options)
     end
 
+    attr_accessor :settings
+
     def deliver!(mail)
-      location = File.join(@options[:location], "#{Time.now.to_i}_#{Digest::SHA1.hexdigest(mail.encoded)[0..6]}")
+      location = File.join(settings[:location], "#{Time.now.to_i}_#{Digest::SHA1.hexdigest(mail.encoded)[0..6]}")
       messages = mail.parts.map { |part| Message.new(location, mail, part) }
       messages << Message.new(location, mail) if messages.empty?
       messages.each { |message| message.render }

--- a/spec/letter_opener/delivery_method_spec.rb
+++ b/spec/letter_opener/delivery_method_spec.rb
@@ -46,5 +46,24 @@ describe LetterOpener::DeliveryMethod do
     html.should include("View plain text version")
     html.should include("<h1>This is HTML</h1>")
   end
+
+
+  it "saves text into html document when deliver! is called" do
+    Launchy.should_receive(:open)
+    mail = Mail.new do
+      from    'foo@example.com'
+      to      'bar@example.com'
+      subject 'Hello'
+      body    'World!'
+    end
+
+    mail.deliver!
+
+    text = File.read(Dir["#{@location}/*/plain.html"].first)
+    text.should include("foo@example.com")
+    text.should include("bar@example.com")
+    text.should include("Hello")
+    text.should include("World!")
+  end
 end
 


### PR DESCRIPTION
https://github.com/ryanb/letter_opener/issues/9

The mail gem expects delivery methods to have the "settings" attribute.  You used "options".  I just changed the letter_opener DeliveryMethod class to more closely conform to those defined in the mail gem.

Included a test.

Thanks for this gem, BTW.  Saved me a bunch of time today.
