### PR TITLE
[Fixed Issue #1] Launchy dependency version

### DIFF
--- a/letter_opener.gemspec
+++ b/letter_opener.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.files        = Dir["{lib,spec}/**/*", "[A-Z]*"] - ["Gemfile.lock"]
   s.require_path = "lib"
 
-  s.add_dependency 'launchy'
+  s.add_dependency 'launchy', '~> 2.0.5'
   s.add_development_dependency 'rspec', '~> 2.6.0'
   s.add_development_dependency 'mail', '~> 2.3.0'
 


### PR DESCRIPTION
Hi Ryan,

After I try your latest gem version, I faced the same problem that described in:
https://github.com/ryanb/letter_opener/issues/1

Then I found the problem caused by old version of Launchy and you don't specify its version in your gemspec. So it will use the version that is available in their local gem list.

Thanks,
Samnang
