### PR TITLE
attempt to fix issue #20

### DIFF
--- a/lib/letter_opener/message.rb
+++ b/lib/letter_opener/message.rb
@@ -20,7 +20,7 @@ module LetterOpener
     end
 
     def filepath
-      File.join(@location, "#{type}.html")
+      File.expand_path( File.join(@location, "#{type}.html") )
     end
 
     def content_type


### PR DESCRIPTION
I don't have a windows image to test this on, I'm wondering if expand_path will put a leading slash so that the `file:///...` url will be parsable at that point.
