### PR TITLE
Avoid margin conflicts in dt, dd.

### DIFF
--- a/lib/letter_opener/message.html.erb
+++ b/lib/letter_opener/message.html.erb
@@ -24,6 +24,7 @@
   #message_headers dt {
     width: 60px;
     padding: 1px;
+    margin: 0;
     float: left;
     text-align: right;
     font-weight: bold;
@@ -31,7 +32,7 @@
   }
 
   #message_headers dd {
-    margin-left: 70px;
+    margin: 0 0 0 70px;
     padding: 1px;
   }
 


### PR DESCRIPTION
When my css has some global styles for `dl dt { margin: 4px 0; }` the message header looks wrong.
