### PR TITLE
Bug with 'letter_opener' folder location after migration to Rails 3.2

### DIFF
--- a/lib/letter_opener/delivery_method.rb
+++ b/lib/letter_opener/delivery_method.rb
@@ -1,7 +1,7 @@
 module LetterOpener
   class DeliveryMethod
     def initialize(options = {})
-      @options = {:location => './letter_opener'}.merge!(options)
+      @options = { :location => defined?(Rails) ? Rails.root.join("tmp", "letter_opener") : './letter_opener' }.merge(options)
     end
 
     def deliver!(mail)


### PR DESCRIPTION
Hi! After we have migrated to Rails 3.2 we got a bug with 'letter_opener' folder location. After sending an email it could appear in the project's root, in 'public', anywhere...
Probably there is a better solution, but we can provide this quick one. It forces to use 'tmp/letter_opener' if it is a Rails app in DeliveryMethod.
