### PR TITLE
Show rich message by default (if available)

### DIFF
--- a/lib/letter_opener/delivery_method.rb
+++ b/lib/letter_opener/delivery_method.rb
@@ -11,7 +11,8 @@ module LetterOpener
       messages = mail.parts.map { |part| Message.new(location, mail, part) }
       messages << Message.new(location, mail) if messages.empty?
       messages.each { |message| message.render }
-      Launchy.open(URI.parse("file://#{messages.first.filepath}"))
+      initial_message = messages.find { |msg| msg.type == 'rich' } || messages.first
+      Launchy.open(URI.parse("file://#{initial_message.filepath}"))
     end
   end
 end


### PR DESCRIPTION
To me this seems as a more useful default than to show a "first" mail part (usually plaintext if both plaintext and rich parts are provided). This is because I need more back-and-forths to tweak complex HTML layout than I need to tweak plaintext email copy.

This would also fix issue #37.
