### PR TITLE
Allow spaces in the application path

### DIFF
--- a/lib/letter_opener/delivery_method.rb
+++ b/lib/letter_opener/delivery_method.rb
@@ -11,7 +11,7 @@ module LetterOpener
       messages = mail.parts.map { |part| Message.new(location, mail, part) }
       messages << Message.new(location, mail) if messages.empty?
       messages.each { |message| message.render }
-      Launchy.open(URI.parse("file://#{messages.first.filepath}"))
+      Launchy.open(URI.parse(URI.escape("file://#{messages.first.filepath}")))
     end
   end
 end


### PR DESCRIPTION
On a Mac, if your Rails app contains spaces in the path, the open will fail with

`URI::InvalidURIError: bad URI(is not URI?)`

Escaping the path corrects this.
