### PR TITLE
Show reply-to if it exists

### DIFF
--- a/lib/letter_opener/message.html.erb
+++ b/lib/letter_opener/message.html.erb
@@ -52,6 +52,11 @@
     <dt>From:</dt>
     <dd><%= from %></dd>
 
+    <% if mail.reply_to %>
+      <dt>Reply-To:</dt>
+      <dd><%= mail.reply_to %></dd>
+    <% end %>
+
     <dt>Subject:</dt>
     <dd><strong><%= mail.subject %></strong></dd>
 

--- a/spec/letter_opener/delivery_method_spec.rb
+++ b/spec/letter_opener/delivery_method_spec.rb
@@ -14,13 +14,15 @@ describe LetterOpener::DeliveryMethod do
   it "saves text into html document" do
     Launchy.should_receive(:open)
     mail = Mail.deliver do
-      from    'Foo foo@example.com'
-      to      'bar@example.com'
-      subject 'Hello'
-      body    'World!'
+      from     'Foo foo@example.com'
+      reply_to 'No Reply no-reply@example.com'
+      to       'bar@example.com'
+      subject  'Hello'
+      body     'World!'
     end
     text = File.read(Dir["#{@location}/*/plain.html"].first)
     text.should include("Foo foo@example.com")
+    text.should include("No Reply no-reply@example.com")
     text.should include("bar@example.com")
     text.should include("Hello")
     text.should include("World!")


### PR DESCRIPTION
If there is a reply-to address, show it also.

Based on the type of email being sent by the app, it is common for us to have the reply-to address be different from the from address. It is useful to see this when letter_opener renders the email.

This is similar to a set of commits I contributed to the 37signals mail_view gem.

(https://github.com/37signals/mail_view/commit/fb2bb6264e89aa7ff43f1683a3c187d561938e88 and https://github.com/37signals/mail_view/commit/e1fab700b2091f2848f5abf0fb29e62fbd3a54ff)
