### PR TITLE
Require erb library when defining Message class

### DIFF
--- a/lib/letter_opener/message.rb
+++ b/lib/letter_opener/message.rb
@@ -1,3 +1,5 @@
+require "erb"
+
 module LetterOpener
   class Message
     attr_reader :mail


### PR DESCRIPTION
When using letter_opener outside of a Rails project, or a codebase where Erb is being used elsewhere,  this require statement is needed to get letter_opener to work.
