### PR TITLE
Patch to support attachment names containing forward slashes.

### DIFF
--- a/lib/letter_opener/message.rb
+++ b/lib/letter_opener/message.rb
@@ -27,7 +27,7 @@ module LetterOpener
         attachments_dir = File.join(@location, 'attachments')
         FileUtils.mkdir_p(attachments_dir)
         mail.attachments.each do |attachment|
-          filename = attachment.filename.gsub(File::SEPARATOR, File::PATH_SEPARATOR)
+          filename = attachment.filename.gsub(/[^\w.]/, '_')
           path = File.join(attachments_dir, filename)
 
           unless File.exists?(path) # true if other parts have already been rendered

--- a/spec/letter_opener/delivery_method_spec.rb
+++ b/spec/letter_opener/delivery_method_spec.rb
@@ -225,7 +225,7 @@ describe LetterOpener::DeliveryMethod do
     end
   end
 
-  context 'attachments on with forward slashes in the filename' do
+  context 'attachments with non-word characters in the filename' do
     before do
       Mail.deliver do
         from      'foo@example.com'
@@ -234,18 +234,18 @@ describe LetterOpener::DeliveryMethod do
         text_part do
           body 'This is <plain> text'
         end
-        attachments['slashes/colons.txt'] = File.read(__FILE__)
+        attachments['non word:chars/used,01.txt'] = File.read(__FILE__)
       end
     end
 
     it 'creates attachments dir with attachment' do
-      attachment = Dir["#{location}/*/attachments/slashes:colons.txt"].first
+      attachment = Dir["#{location}/*/attachments/non_word_chars_used_01.txt"].first
       File.exists?(attachment).should be_true
     end
 
     it 'saves attachment name' do
       plain = File.read(Dir["#{location}/*/plain.html"].first)
-      plain.should include('slashes:colons.txt')
+      plain.should include('non_word_chars_used_01.txt')
     end
   end
 


### PR DESCRIPTION
One of my mailers has an attachment whose file name contains forward slashes.  I should change that, but this causes letter_opener to fail.  The attached pull request converts forward slashes (well, technically File::SEPARATOR) to colons (File::PATH_SEPARATOR) before creating/building the files on disk.
