### PR TITLE
Loosen Launchy version dependency

### DIFF
--- a/letter_opener.gemspec
+++ b/letter_opener.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.files        = Dir["{lib,spec}/**/*", "[A-Z]*"] - ["Gemfile.lock"]
   s.require_path = "lib"
 
-  s.add_dependency 'launchy', '>= 2.2.0', '< 3.0'
+  s.add_dependency 'launchy', '~> 2.2'
   s.add_development_dependency 'rspec', '~> 2.12.0'
   s.add_development_dependency 'mail', '~> 2.5.0'
 


### PR DESCRIPTION
I loosened the version dependency for `Launchy` to allow for the newest 2.3.0 version (and all versions until 3.0)
