### PR TITLE
Not opening mail in browser

### DIFF
--- a/lib/letter_opener/delivery_method.rb
+++ b/lib/letter_opener/delivery_method.rb
@@ -12,7 +12,7 @@ module LetterOpener
     def deliver!(mail)
       location = File.join(settings[:location], "#{Time.now.to_i}_#{Digest::SHA1.hexdigest(mail.encoded)[0..6]}")
       messages = Message.rendered_messages(location, mail)
-      Launchy.open(URI.escape(messages.first.filepath))
+      Launchy.open("file://" + URI.parse(URI.escape(messages.first.filepath)).to_s)
     end
   end
 end


### PR DESCRIPTION
I set up letter_opener in my rails project, but when delivering the email it didn't open in the browser as it used to do. I have used letter_opener before, but this time wasn't working.

The problem was that Launchy could not open the file. I was getting this error

```
Launchy::ApplicationNotFoundError: No application found to handle '/Users/adrian/Icalia%20Labs/tmp/letter_opener/1368036004_b89703f/rich.html'
```

I tried it in the console using the direct path for the file and it was working without the `URI.escape(filepath)` but when I tried escaping the filepath I got the same error. Adding `file://` solves it.
Maybe is an error with Launchy.

I checked out the code and saw that this line in file `lib/letter_opener/delivery_method.rb` 
has been changing on and off adding the `file://` part

```
Launchy.open(URI.parse(URI.escape(messages.first.filepath)).to_s)
```

My question is, why did you decide to remove `file://` part?
Does anybody have the same issue?
I made a fork and reverting to add the `file://` worked for me.
