### PR TITLE
Add margin below message headers.

### DIFF
--- a/lib/letter_opener/message.html.erb
+++ b/lib/letter_opener/message.html.erb
@@ -7,7 +7,7 @@
   #message_headers {
     width: 100%;
     padding: 10px 0 0 0;
-    margin: 0;
+    margin: 0 0 10px;
     background: #fff;
     font-size: 12px;
     font-family: "Lucida Grande";


### PR DESCRIPTION
Adds a 10px margin below the line that separates the message headers and the message. I was working on a responsive email that has no margins (email clients always create their own margins) and my content was right against the border. Others may have the same display problem.

![sample](https://f.cloud.github.com/assets/58460/944292/9b443e74-02a4-11e3-9ad1-1f3cfc5a1bb2.png)
