### PR TITLE
Add perform_deliveries configuration note

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -12,6 +12,7 @@ First add the gem to your development environment and run the +bundle+ command t
 Then set the delivery method in <tt>config/environments/development.rb</tt>
 
   config.action_mailer.delivery_method = :letter_opener
+  config.action_mailer.perform_deliveries = true
 
 Now any email will pop up in your browser instead of being sent. The messages are stored in <tt>tmp/letter_opener</tt>.
 


### PR DESCRIPTION
perform_deliveries is false by default in development, but letter_opener requires it to be enabled.
