### PR TITLE
Upgrade rspec to 2.14 and update to expect over should syntax

### DIFF
--- a/letter_opener.gemspec
+++ b/letter_opener.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.require_path = "lib"
 
   s.add_dependency 'launchy', '~> 2.2'
-  s.add_development_dependency 'rspec', '~> 2.12.0'
+  s.add_development_dependency 'rspec', '~> 2.14.0'
   s.add_development_dependency 'mail', '~> 2.5.0'
 
   s.rubyforge_project = s.name

--- a/spec/letter_opener/delivery_method_spec.rb
+++ b/spec/letter_opener/delivery_method_spec.rb
@@ -17,8 +17,8 @@ describe LetterOpener::DeliveryMethod do
   end
 
   it 'raises an exception if no location passed' do
-    lambda { LetterOpener::DeliveryMethod.new }.should raise_exception(LetterOpener::DeliveryMethod::InvalidOption)
-    lambda { LetterOpener::DeliveryMethod.new(location: "foo") }.should_not raise_exception
+    expect { LetterOpener::DeliveryMethod.new }.to raise_exception(LetterOpener::DeliveryMethod::InvalidOption)
+    expect { LetterOpener::DeliveryMethod.new(location: "foo") }.to_not raise_exception
   end
 
   context 'integration' do
@@ -55,7 +55,7 @@ describe LetterOpener::DeliveryMethod do
   context 'content' do
     context 'plain' do
       before do
-        Launchy.should_receive(:open)
+        expect(Launchy).to receive(:open)
 
         Mail.deliver do
           from     'Foo <foo@example.com>'
@@ -70,31 +70,31 @@ describe LetterOpener::DeliveryMethod do
       end
 
       it 'creates plain html document' do
-        File.exist?(plain_file).should be_true
+        expect(File.exist?(plain_file)).to be_true
       end
 
       it 'saves From field' do
-        plain.should include("Foo <foo@example.com>")
+        expect(plain).to include("Foo <foo@example.com>")
       end
 
       it 'saves Sender field' do
-        plain.should include("Baz <baz@example.com>")
+        expect(plain).to include("Baz <baz@example.com>")
       end
 
       it 'saves Reply-to field' do
-        plain.should include("No Reply <no-reply@example.com>")
+        expect(plain).to include("No Reply <no-reply@example.com>")
       end
 
       it 'saves To field' do
-        plain.should include("Bar <bar@example.com>")
+        expect(plain).to include("Bar <bar@example.com>")
       end
 
       it 'saves Subject field' do
-        plain.should include("Hello")
+        expect(plain).to include("Hello")
       end
 
       it 'saves Body with autolink' do
-        plain.should include('World! <a href="http://example.com">http://example.com</a>')
+        expect(plain).to include('World! <a href="http://example.com">http://example.com</a>')
       end
     end
 
@@ -103,7 +103,7 @@ describe LetterOpener::DeliveryMethod do
       let(:rich) { CGI.unescape_html(File.read(rich_file)) }
 
       before do
-        Launchy.should_receive(:open)
+        expect(Launchy).to receive(:open)
 
         Mail.deliver do
           from    'foo@example.com'
@@ -120,31 +120,31 @@ describe LetterOpener::DeliveryMethod do
       end
 
       it 'creates plain html document' do
-        File.exist?(plain_file).should be_true
+        expect(File.exist?(plain_file)).to be_true
       end
 
       it 'creates rich html document' do
-        File.exist?(rich_file).should be_true
+        expect(File.exist?(rich_file)).to be_true
       end
 
       it 'shows link to rich html version' do
-        plain.should include("View HTML version")
+        expect(plain).to include("View HTML version")
       end
 
       it 'saves text part' do
-        plain.should include("This is <plain> text")
+        expect(plain).to include("This is <plain> text")
       end
 
       it 'saves html part' do
-        rich.should include("<h1>This is HTML</h1>")
+        expect(rich).to include("<h1>This is HTML</h1>")
       end
 
       it 'saves escaped Subject field' do
-        plain.should include("Many parts with <html>")
+        expect(plain).to include("Many parts with <html>")
       end
 
       it 'shows subject as title' do
-        rich.should include("<title>Many parts with <html></title>")
+        expect(rich).to include("<title>Many parts with <html></title>")
       end
     end
   end
@@ -153,7 +153,7 @@ describe LetterOpener::DeliveryMethod do
     let(:location) { File.expand_path('../../../tmp/letter_opener with space', __FILE__) }
 
     before do
-      Launchy.should_receive(:open)
+      expect(Launchy).to receive(:open)
 
       Mail.deliver do
         from     'Foo <foo@example.com>'
@@ -168,13 +168,13 @@ describe LetterOpener::DeliveryMethod do
     end
 
     it 'saves From filed' do
-      plain.should include("Foo <foo@example.com>")
+      expect(plain).to include("Foo <foo@example.com>")
     end
   end
 
   context 'using deliver! method' do
     before do
-      Launchy.should_receive(:open)
+      expect(Launchy).to receive(:open)
       Mail.new do
         from    'foo@example.com'
         to      'bar@example.com'
@@ -184,23 +184,23 @@ describe LetterOpener::DeliveryMethod do
     end
 
     it 'creates plain html document' do
-      File.exist?(plain_file).should be_true
+      expect(File.exist?(plain_file)).to be_true
     end
 
     it 'saves From field' do
-      plain.should include("foo@example.com")
+      expect(plain).to include("foo@example.com")
     end
 
     it 'saves To field' do
-      plain.should include("bar@example.com")
+      expect(plain).to include("bar@example.com")
     end
 
     it 'saves Subject field' do
-      plain.should include("Hello")
+      expect(plain).to include("Hello")
     end
 
     it 'saves Body field' do
-      plain.should include("World!")
+      expect(plain).to include("World!")
     end
   end
 
@@ -219,12 +219,12 @@ describe LetterOpener::DeliveryMethod do
 
     it 'creates attachments dir with attachment' do
       attachment = Dir["#{location}/*/attachments/#{File.basename(__FILE__)}"].first
-      File.exists?(attachment).should be_true
+      expect(File.exists?(attachment)).to be_true
     end
 
     it 'saves attachment name' do
       plain = File.read(Dir["#{location}/*/plain.html"].first)
-      plain.should include(File.basename(__FILE__))
+      expect(plain).to include(File.basename(__FILE__))
     end
   end
 
@@ -247,14 +247,14 @@ describe LetterOpener::DeliveryMethod do
 
     it 'creates attachments dir with attachment' do
       attachment = Dir["#{location}/*/attachments/#{File.basename(__FILE__)}"].first
-      File.exists?(attachment).should be_true
+      expect(File.exists?(attachment)).to be_true
     end
 
     it 'replaces inline attachment urls' do
       text = File.read(Dir["#{location}/*/rich.html"].first)
-      mail.parts[0].body.should include(url)
-      text.should_not include(url)
-      text.should include("attachments/#{File.basename(__FILE__)}")
+      expect(mail.parts[0].body).to include(url)
+      expect(text).to_not include(url)
+      expect(text).to include("attachments/#{File.basename(__FILE__)}")
     end
   end
 
@@ -273,19 +273,19 @@ describe LetterOpener::DeliveryMethod do
 
     it 'creates attachments dir with attachment' do
       attachment = Dir["#{location}/*/attachments/non_word_chars_used_01.txt"].first
-      File.exists?(attachment).should be_true
+      expect(File.exists?(attachment)).to be_true
     end
 
     it 'saves attachment name' do
       plain = File.read(Dir["#{location}/*/plain.html"].first)
-      plain.should include('non_word_chars_used_01.txt')
+      expect(plain).to include('non_word_chars_used_01.txt')
     end
   end
 
 
   context 'subjectless mail' do
     before do
-      Launchy.should_receive(:open)
+      expect(Launchy).to receive(:open)
 
       Mail.deliver do
         from     'Foo foo@example.com'
@@ -296,7 +296,7 @@ describe LetterOpener::DeliveryMethod do
     end
 
     it 'creates plain html document' do
-      File.exist?(plain_file).should be_true
+      expect(File.exist?(plain_file)).to be_true
     end
   end
 end

--- a/spec/letter_opener/message_spec.rb
+++ b/spec/letter_opener/message_spec.rb
@@ -11,25 +11,25 @@ describe LetterOpener::Message do
     it 'handles one email as a string' do
       mail    = mail(:reply_to => 'test@example.com')
       message = described_class.new(location, mail)
-      message.reply_to.should eq('test@example.com')
+      expect(message.reply_to).to eq('test@example.com')
     end
 
     it 'handles one email with display names' do
       mail    = mail(:reply_to => 'test <test@example.com>')
       message = described_class.new(location, mail)
-      message.reply_to.should eq('test <test@example.com>')
+      expect(message.reply_to).to eq('test <test@example.com>')
     end
 
     it 'handles array of emails' do
       mail    = mail(:reply_to => ['test1@example.com', 'test2@example.com'])
       message = described_class.new(location, mail)
-      message.reply_to.should eq('test1@example.com, test2@example.com')
+      expect(message.reply_to).to eq('test1@example.com, test2@example.com')
     end
 
     it 'handles array of emails with display names' do
       mail    = mail(:reply_to => ['test1 <test1@example.com>', 'test2 <test2@example.com>'])
       message = described_class.new(location, mail)
-      message.reply_to.should eq('test1 <test1@example.com>, test2 <test2@example.com>')
+      expect(message.reply_to).to eq('test1 <test1@example.com>, test2 <test2@example.com>')
     end
 
   end
@@ -38,25 +38,25 @@ describe LetterOpener::Message do
     it 'handles one email as a string' do
       mail   = mail(:to => 'test@example.com')
       message = described_class.new(location, mail)
-      message.to.should eq('test@example.com')
+      expect(message.to).to eq('test@example.com')
     end
 
     it 'handles one email with display names' do
       mail    = mail(:to => 'test <test@example.com>')
       message = described_class.new(location, mail)
-      message.to.should eq('test <test@example.com>')
+      expect(message.to).to eq('test <test@example.com>')
     end
 
     it 'handles array of emails' do
       mail    = mail(:to => ['test1@example.com', 'test2@example.com'])
       message = described_class.new(location, mail)
-      message.to.should eq('test1@example.com, test2@example.com')
+      expect(message.to).to eq('test1@example.com, test2@example.com')
     end
 
     it 'handles array of emails with display names' do
       mail    = mail(:to => ['test1 <test1@example.com>', 'test2 <test2@example.com>'])
       message = described_class.new(location, mail)
-      message.to.should eq('test1 <test1@example.com>, test2 <test2@example.com>')
+      expect(message.to).to eq('test1 <test1@example.com>, test2 <test2@example.com>')
     end
 
   end
@@ -65,25 +65,25 @@ describe LetterOpener::Message do
     it 'handles one cc email as a string' do
       mail    = mail(:cc => 'test@example.com')
       message = described_class.new(location, mail)
-      message.cc.should eq('test@example.com')
+      expect(message.cc).to eq('test@example.com')
     end
 
     it 'handles one cc email with display name' do
       mail    = mail(:cc => ['test <test1@example.com>', 'test2 <test2@example.com>'])
       message = described_class.new(location, mail)
-      message.cc.should eq('test <test1@example.com>, test2 <test2@example.com>')
+      expect(message.cc).to eq('test <test1@example.com>, test2 <test2@example.com>')
     end
 
     it 'handles array of cc emails' do
       mail    = mail(:cc => ['test1@example.com', 'test2@example.com'])
       message = described_class.new(location, mail)
-      message.cc.should eq('test1@example.com, test2@example.com')
+      expect(message.cc).to eq('test1@example.com, test2@example.com')
     end
 
     it 'handles array of cc emails with display names' do
       mail    = mail(:cc => ['test <test1@example.com>', 'test2 <test2@example.com>'])
       message = described_class.new(location, mail)
-      message.cc.should eq('test <test1@example.com>, test2 <test2@example.com>')
+      expect(message.cc).to eq('test <test1@example.com>, test2 <test2@example.com>')
     end
 
   end
@@ -92,25 +92,25 @@ describe LetterOpener::Message do
     it 'handles one bcc email as a string' do
       mail    = mail(:bcc => 'test@example.com')
       message = described_class.new(location, mail)
-      message.bcc.should eq('test@example.com')
+      expect(message.bcc).to eq('test@example.com')
     end
 
     it 'handles one bcc email with display name' do
       mail    = mail(:bcc => ['test <test1@example.com>', 'test2 <test2@example.com>'])
       message = described_class.new(location, mail)
-      message.bcc.should eq('test <test1@example.com>, test2 <test2@example.com>')
+      expect(message.bcc).to eq('test <test1@example.com>, test2 <test2@example.com>')
     end
 
     it 'handles array of bcc emails' do
       mail    = mail(:bcc => ['test1@example.com', 'test2@example.com'])
       message = described_class.new(location, mail)
-      message.bcc.should eq('test1@example.com, test2@example.com')
+      expect(message.bcc).to eq('test1@example.com, test2@example.com')
     end
 
     it 'handles array of bcc emails with display names' do
       mail    = mail(:bcc => ['test <test1@example.com>', 'test2 <test2@example.com>'])
       message = described_class.new(location, mail)
-      message.bcc.should eq('test <test1@example.com>, test2 <test2@example.com>')
+      expect(message.bcc).to eq('test <test1@example.com>, test2 <test2@example.com>')
     end
 
   end
@@ -119,25 +119,25 @@ describe LetterOpener::Message do
     it 'handles one email as a string' do
       mail    = mail(:sender => 'sender@example.com')
       message = described_class.new(location, mail)
-      message.sender.should eq('sender@example.com')
+      expect(message.sender).to eq('sender@example.com')
     end
 
     it 'handles one email as a string with display name' do
       mail    = mail(:sender => 'test <test@example.com>')
       message = described_class.new(location, mail)
-      message.sender.should eq('test <test@example.com>')
+      expect(message.sender).to eq('test <test@example.com>')
     end
 
     it 'handles array of emails' do
       mail    = mail(:sender => ['sender1@example.com', 'sender2@example.com'])
       message = described_class.new(location, mail)
-      message.sender.should eq('sender1@example.com, sender2@example.com')
+      expect(message.sender).to eq('sender1@example.com, sender2@example.com')
     end
 
     it 'handles array of emails with display names' do
       mail    = mail(:sender => ['test <test1@example.com>', 'test2 <test2@example.com>'])
       message = described_class.new(location, mail)
-      message.sender.should eq('test <test1@example.com>, test2 <test2@example.com>')
+      expect(message.sender).to eq('test <test1@example.com>, test2 <test2@example.com>')
     end
 
   end
@@ -146,7 +146,7 @@ describe LetterOpener::Message do
     it 'sorts rich type before plain type' do
       plain = described_class.new(location, mock(content_type: 'text/plain'))
       rich  = described_class.new(location, mock(content_type: 'text/html'))
-      [plain, rich].sort.should eq([rich, plain])
+      expect([plain, rich].sort).to eq([rich, plain])
     end
   end
 end


### PR DESCRIPTION
I would like to offer this branch for consideration.
I bumped rspec up to 2.14
I'm offering the rspec expect().to syntax for consideration.
As you may well know, using 'expect' over 'should' is a recommended practice because of dealing with delegate/proxy objects as detailed in http://myronmars.to/n/dev-blog/2012/06/rspecs-new-expectation-syntax.
As detailed in the blog post "In the future, we plan to change the defaults so that only expect is available unless you explicitly enable should. We may do this as soon as RSpec 3.0, but we want to give users plenty of time to get acquianted with it."
I noticed that expect is now being used in many of the major gems that use rspec. 
I changed any pattern matchers from =~ to match() or match_array() as required for this change and while at it I also took the opportunity to change the == format to eq as recommended in the post.
All tests still pass after this change.
