### PR TITLE
Fix deprecations and warnings in spec output

### DIFF
--- a/spec/letter_opener/delivery_method_spec.rb
+++ b/spec/letter_opener/delivery_method_spec.rb
@@ -29,12 +29,13 @@ describe LetterOpener::DeliveryMethod do
 
     context 'normal location path' do
       it 'opens email' do
+        expect($stdout).to receive(:puts)
         expect {
           Mail.deliver do
             from 'Foo foo@example.com'
             body 'World! http://example.com'
           end
-        }.not_to raise_error(Launchy::ApplicationNotFoundError)
+        }.not_to raise_error
       end
     end
 
@@ -42,12 +43,13 @@ describe LetterOpener::DeliveryMethod do
       let(:location) { File.expand_path('../../../tmp/letter_opener with space', __FILE__) }
 
       it 'opens email' do
+        expect($stdout).to receive(:puts)
         expect {
           Mail.deliver do
             from 'Foo foo@example.com'
             body 'World! http://example.com'
           end
-        }.not_to raise_error(Launchy::ApplicationNotFoundError)
+        }.not_to raise_error
       end
     end
   end

--- a/spec/letter_opener/message_spec.rb
+++ b/spec/letter_opener/message_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe LetterOpener::Message do
   let(:location) { File.expand_path('../../../tmp/letter_opener', __FILE__) }
 
-  def mail(options)
+  def mail(options={})
     Mail.new(options)
   end
 
@@ -144,9 +144,24 @@ describe LetterOpener::Message do
 
   describe '#<=>' do
     it 'sorts rich type before plain type' do
-      plain = described_class.new(location, mock(content_type: 'text/plain'))
-      rich  = described_class.new(location, mock(content_type: 'text/html'))
+      plain = described_class.new(location, double(content_type: 'text/plain'))
+      rich  = described_class.new(location, double(content_type: 'text/html'))
       expect([plain, rich].sort).to eq([rich, plain])
+    end
+  end
+
+  describe '#auto_link' do
+    let(:message){ described_class.new(location, mail) }
+
+    it 'should not modify unlinkable text' do
+      text = 'the quick brown fox jumped over the lazy dog'
+      expect(message.auto_link(text)).to eq(text)
+    end
+
+    it 'should add links for http' do
+      raw = "Link to http://localhost:3000/example/path path"
+      linked = "Link to <a href=\"http://localhost:3000/example/path\">http://localhost:3000/example/path</a> path"
+      expect(message.auto_link(raw)).to eq(linked)
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,5 @@ require "mail"
 
 RSpec.configure do |config|
   config.treat_symbols_as_metadata_keys_with_true_values = true
-  config.filter_run :focus => true
   config.run_all_when_everything_filtered = true
 end


### PR DESCRIPTION
The tests are all passing, but the output is messy. The tests also use some deprecated rspec features which throw warnings. Output looks like:

```
~/C/R/letter_opener(master)$ bundle exec rspec
Run options: include {:focus=>true}

All examples were filtered out; ignoring {:focus=>true}
......................DEPRECATION: `expect { }.not_to raise_error(SpecificErrorClass)` is deprecated. Use `expect { }.not_to raise_error` (with no args) instead. Called from /Users/kevinmcphillips/Code/Ruby/letter_opener/spec/letter_opener/delivery_method_spec.rb:32:in `block (4 levels) in <top (required)>'.
/usr/bin/open file:////Users/kevinmcphillips/Code/Ruby/letter_opener/tmp/letter_opener/1386427151_385c31e/plain.html
.DEPRECATION: `expect { }.not_to raise_error(SpecificErrorClass)` is deprecated. Use `expect { }.not_to raise_error` (with no args) instead. Called from /Users/kevinmcphillips/Code/Ruby/letter_opener/spec/letter_opener/delivery_method_spec.rb:45:in `block (4 levels) in <top (required)>'.
/usr/bin/open file:////Users/kevinmcphillips/Code/Ruby/letter_opener/tmp/letter_opener%20with%20space/1386427151_bf4fc7b/plain.html
............................DEPRECATION: mock is deprecated. Use double instead. Called from /Users/kevinmcphillips/Code/Ruby/letter_opener/spec/letter_opener/message_spec.rb:147:in `block (3 levels) in <top (required)>'.
DEPRECATION: mock is deprecated. Use double instead. Called from /Users/kevinmcphillips/Code/Ruby/letter_opener/spec/letter_opener/message_spec.rb:148:in `block (3 levels) in <top (required)>'.
.

Finished in 0.63647 seconds
52 examples, 0 failures

Randomized with seed 52632
```

I cleaned up the tests as follows: replaced `mock` with `double`, removed unneeded option in init, changed the `raise_error` expectation syntax, and added some missing tests. Output now looks like:

```
~/C/R/letter_opener(master)$ bundle exec rspec
......................................................

Finished in 0.64368 seconds
54 examples, 0 failures

Randomized with seed 52402
```
