### PR TITLE
Lazy-load ActionMailer::Base to defer :action_mailer on_load hook

### DIFF
--- a/lib/letter_opener/railtie.rb
+++ b/lib/letter_opener/railtie.rb
@@ -1,7 +1,9 @@
 module LetterOpener
   class Railtie < Rails::Railtie
     initializer "letter_opener.add_delivery_method" do
-      ActionMailer::Base.add_delivery_method :letter_opener, LetterOpener::DeliveryMethod, :location => Rails.root.join("tmp", "letter_opener")
+      ActiveSupport.on_load :action_mailer do
+        ActionMailer::Base.add_delivery_method :letter_opener, LetterOpener::DeliveryMethod, :location => Rails.root.join("tmp", "letter_opener")
+      end
     end
   end
 end


### PR DESCRIPTION
Bundling current version of letter_opener immediately loads ActionMailer::Base when the gem is required, and thus triggers its whole initialization scripts (and then ActionMailer loads ActionView [here](https://github.com/rails/rails/blob/5d037819ca80606638212f83de741cc2041db28f/actionmailer/lib/action_mailer/base.rb#L415)) even in situations that ActionMailer or ActionView are not actually needed (e.g. booting up the Rails console, executing a model test, running a Rake task, etc.).

Here's a fix to lazy-load AM::Base via ActiveSupport.on_load hook so that AM::Base is loaded when actually referenced from the application.
