### PR TITLE
Removing fixed width

### DIFF
--- a/lib/letter_opener/message.html.erb
+++ b/lib/letter_opener/message.html.erb
@@ -8,7 +8,6 @@
     <style type="text/css">
       #container {
         margin: 10px auto;
-        width: 800px;
       }
       #message_headers {
         background: #fff;


### PR DESCRIPTION
No need for this fixed width definition, just makes it harder to resize browser window and see what the email looks like on different resolutions
