### PR TITLE
Add simple throttling to letter_opener

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -49,6 +49,11 @@ Letter Opener uses {Launchy}[https://github.com/copiousfreetime/launchy] to open
 
 In order to keep this project simple, I don't have plans to turn it into a Rails engine with an interface for browsing the sent mail but there is a [gem you can use for that](https://github.com/fgrehm/letter_opener_web).
 
+== Throttling
+
+When sending tens or hunderds of emails opening each is very time consuming. A simple throttling mechanism is available to handle such mass mailing situation better. Once the max rate specified reached letter_opener will stop opening the mails, but it still keep the files so you can view the location should you need to. Example:
+
+  config.action_mailer.letter_opener_settings = {max_rate: {messages: 5, every: 20.seconds}}
 
 == Development & Feedback
 

--- a/lib/letter_opener/delivery_method.rb
+++ b/lib/letter_opener/delivery_method.rb
@@ -1,18 +1,40 @@
+require 'byebug'
+
 module LetterOpener
   class DeliveryMethod
     class InvalidOption < StandardError; end
 
     attr_accessor :settings
 
+    def self.default_settings=(settings)
+      @@default_settings=settings
+    end
+    @@default_settings = {}
+
     def initialize(options = {})
+      options = options.merge(@@default_settings||{})
       raise InvalidOption, "A location option is required when using the Letter Opener delivery method" if options[:location].nil?
+      raise InvalidOptions "Letter Opener max_rate requires Hash with messages and every keys" if options[:max_rate] &&
+        (options[:max_rate][:messages].nil? || options[:max_rate][:every].nil?)
       self.settings = options
     end
 
     def deliver!(mail)
       location = File.join(settings[:location], "#{Time.now.to_i}_#{Digest::SHA1.hexdigest(mail.encoded)[0..6]}")
       messages = Message.rendered_messages(location, mail)
-      Launchy.open("file:///#{URI.parse(URI.escape(messages.first.filepath))}")
+      Launchy.open("file:///#{URI.parse(URI.escape(messages.first.filepath))}") unless throttle_send
+    end
+
+    def throttle_send
+      if self.settings[:max_rate]
+        max_msg_count,period = self.settings[:max_rate].values_at(:messages,:every)
+        @@sent_times ||= []
+        now = Time.now
+        @@sent_times = @@sent_times.drop_while {|i| i < now-period }
+        return true if @@sent_times.size >= max_msg_count
+        @@sent_times.push now
+      end
+      false
     end
   end
 end

--- a/lib/letter_opener/railtie.rb
+++ b/lib/letter_opener/railtie.rb
@@ -1,8 +1,10 @@
 module LetterOpener
   class Railtie < Rails::Railtie
-    initializer "letter_opener.add_delivery_method" do
+    initializer "letter_opener.add_delivery_method", before: 'action_mailer.set_configs' do
       ActiveSupport.on_load :action_mailer do
-        ActionMailer::Base.add_delivery_method :letter_opener, LetterOpener::DeliveryMethod, :location => Rails.root.join("tmp", "letter_opener")
+        default_options = {:location => Rails.root.join("tmp", "letter_opener"), :max_msg => nil}
+        LetterOpener::DeliveryMethod.default_settings = default_options
+        ActionMailer::Base.add_delivery_method :letter_opener, LetterOpener::DeliveryMethod, default_options
       end
     end
   end


### PR DESCRIPTION
In the settings a max_rate with a max number of messages over a period of time.
If this is configured we stop opening generated mails for those that would exceed this rate.
