### PR TITLE
Put html email body in an iframe for proper rendering

### DIFF
--- a/lib/letter_opener/message.html.erb
+++ b/lib/letter_opener/message.html.erb
@@ -124,7 +124,7 @@
       <% if type == "plain" %>
         <pre id="message_body"><%= auto_link(h(body)) %></pre>
       <% else %>
-        <iframe seamless="seamless" srcdoc="<%= body %>"></iframe>
+        <iframe seamless="seamless" srcdoc="<%= h(body) %>"></iframe>
       <% end %>
     </div>
   </body>


### PR DESCRIPTION
The HTML part of an email is usually a full HTML document (with an `<html>` tag).  Currently letter_opener renders this document directly inside another HTML document. This results in invalid HTML. Furthermore, script tags in the inner HTML document are ignored. This breaks the `@media` queries which drive responsive email layouts.

This patch renders the HTML part in an iframe, much like [mail_view does](https://github.com/basecamp/mail_view/blob/master/lib/mail_view/email.html.erb#L99).  It will fix ryanb/letter_opener#98
