### PR TITLE
Save the raw email in .eml file

### DIFF
--- a/lib/letter_opener/message.rb
+++ b/lib/letter_opener/message.rb
@@ -5,12 +5,22 @@ module LetterOpener
     attr_reader :mail
 
     def self.rendered_messages(location, mail)
+      FileUtils.mkdir_p(location)
+
+      render_raw(location, mail)
+
       messages = []
       messages << new(location, mail, mail.html_part) if mail.html_part
       messages << new(location, mail, mail.text_part) if mail.text_part
       messages << new(location, mail) if messages.empty?
       messages.each(&:render)
       messages.sort
+    end
+
+    def self.render_raw(location, mail)
+      path = File.join(location, "message.eml")
+
+      File.open(path, 'w') { |f| f.write(mail.to_s) }
     end
 
     def initialize(location, mail, part = nil)
@@ -21,8 +31,6 @@ module LetterOpener
     end
 
     def render
-      FileUtils.mkdir_p(@location)
-
       if mail.attachments.any?
         attachments_dir = File.join(@location, 'attachments')
         FileUtils.mkdir_p(attachments_dir)

--- a/spec/letter_opener/delivery_method_spec.rb
+++ b/spec/letter_opener/delivery_method_spec.rb
@@ -3,6 +3,9 @@ require "spec_helper"
 describe LetterOpener::DeliveryMethod do
   let(:location)   { File.expand_path('../../../tmp/letter_opener', __FILE__) }
 
+  let(:eml_file) { Dir["#{location}/*/message.eml"].first }
+  let(:eml)      { CGI.unescape_html(File.read(eml_file)) }
+
   let(:plain_file) { Dir["#{location}/*/plain.html"].first }
   let(:plain)      { CGI.unescape_html(File.read(plain_file)) }
 
@@ -59,7 +62,7 @@ describe LetterOpener::DeliveryMethod do
       before do
         expect(Launchy).to receive(:open)
 
-        Mail.deliver do
+        @mail = Mail.deliver do
           from     'Foo <foo@example.com>'
           sender   'Baz <baz@example.com>'
           reply_to 'No Reply <no-reply@example.com>'
@@ -73,6 +76,10 @@ describe LetterOpener::DeliveryMethod do
 
       it 'creates plain html document' do
         expect(File.exist?(plain_file)).to be_true
+      end
+
+      it 'creates eml document' do
+        expect(File.exist?(eml_file)).to be_true
       end
 
       it 'saves From field' do
@@ -98,6 +105,10 @@ describe LetterOpener::DeliveryMethod do
       it 'saves Body with autolink' do
         expect(plain).to include('World! <a href="http://example.com">http://example.com</a>')
       end
+
+      it 'saves eml document' do
+        expect(eml).to eq(@mail.to_s)
+      end
     end
 
     context 'multipart' do
@@ -107,7 +118,7 @@ describe LetterOpener::DeliveryMethod do
       before do
         expect(Launchy).to receive(:open)
 
-        Mail.deliver do
+        @mail = Mail.deliver do
           from    'foo@example.com'
           to      'bar@example.com'
           subject 'Many parts with <html>'
@@ -129,6 +140,10 @@ describe LetterOpener::DeliveryMethod do
         expect(File.exist?(rich_file)).to be_true
       end
 
+      it 'creates eml document' do
+        expect(File.exist?(eml_file)).to be_true
+      end
+
       it 'shows link to rich html version' do
         expect(plain).to include("View HTML version")
       end
@@ -147,6 +162,10 @@ describe LetterOpener::DeliveryMethod do
 
       it 'shows subject as title' do
         expect(rich).to include("<title>Many parts with <html></title>")
+      end
+
+      it 'saves eml document' do
+        expect(eml).to eq(@mail.to_s)
       end
     end
   end


### PR DESCRIPTION
I think it could be interesting to save the raw email into a `.eml` file in addition to the `.html` file(s).