### PR TITLE
Stop base tag appearing in plain-text previews

### DIFF
--- a/lib/letter_opener/message.html.erb
+++ b/lib/letter_opener/message.html.erb
@@ -124,7 +124,7 @@
       <% if type == "plain" %>
         <pre id="message_body"><%= auto_link(h(body)) %></pre>
       <% else %>
-        <iframe seamless="seamless" srcdoc="<%= h(body) %>"></iframe>
+        <iframe seamless="seamless" srcdoc="<base target='_top'><%= h(body) %>"></iframe>
       <% end %>
     </div>
   </body>

--- a/lib/letter_opener/message.rb
+++ b/lib/letter_opener/message.rb
@@ -63,7 +63,7 @@ module LetterOpener
           body.gsub!(attachment.url, "attachments/#{attachment.filename}")
         end
 
-        base_tag + body
+        body
       end
     end
 
@@ -97,11 +97,6 @@ module LetterOpener
 
     def encoding
       body.respond_to?(:encoding) ? body.encoding : "utf-8"
-    end
-
-    # To make links work in iframe with X-Frame-Options set to SAMEORIGIN
-    def base_tag
-      '<base target="_top">'
     end
 
     def auto_link(text)


### PR DESCRIPTION
This PR fixes https://github.com/ryanb/letter_opener/issues/107 by moving the `<base target="_top">` tag out of the `LetterOpener::Message` class and into the `message.html.erb` template. Since this is essentially a view concern, it makes sense to make use of the existing plain vs. html logic and only prepend the base tag when previewing HTML parts of emails.

/cc @nashby 