### PR TITLE
Fix non-Rails with actionmailer 4.2.3

### DIFF
--- a/lib/letter_opener.rb
+++ b/lib/letter_opener.rb
@@ -6,4 +6,4 @@ require "launchy"
 
 require "letter_opener/message"
 require "letter_opener/delivery_method"
-require "letter_opener/railtie" if defined? Rails
+require "letter_opener/railtie" if defined?(Rails) && defined?(Rails::Railtie)


### PR DESCRIPTION
The latest version of letter_opener doesn't work with the latest version of actionmailer when being used standalone (without Rails). I believe the reason is that the "Rails" constant is being defined by actionmailer (or rather by [rails-html-sanitizer](https://github.com/rails/rails-html-sanitizer/blob/4f0f7810fce6c8aa63de07a40d69d6027a30acaf/lib/rails/html/sanitizer/version.rb#L1)).

This PR fixes that by also checking for "Rails::Railtie". Not a nice fix, but works.

@ryanb @davidcornu please take a quick look