### PR TITLE
Allow underscore and hyphen in attachment name

### DIFF
--- a/lib/letter_opener/message.rb
+++ b/lib/letter_opener/message.rb
@@ -27,7 +27,7 @@ module LetterOpener
         attachments_dir = File.join(@location, 'attachments')
         FileUtils.mkdir_p(attachments_dir)
         mail.attachments.each do |attachment|
-          filename = attachment.filename.gsub(/[^\w.]/, '_')
+          filename = attachment.filename.gsub(/[^\w\-_.]/, '_')
           path = File.join(attachments_dir, filename)
 
           unless File.exists?(path) # true if other parts have already been rendered

--- a/spec/letter_opener/delivery_method_spec.rb
+++ b/spec/letter_opener/delivery_method_spec.rb
@@ -271,18 +271,18 @@ describe LetterOpener::DeliveryMethod do
         text_part do
           body 'This is <plain> text'
         end
-        attachments['non word:chars/used,01.txt'] = File.read(__FILE__)
+        attachments['non word:chars/used,01-02.txt'] = File.read(__FILE__)
       end
     end
 
     it 'creates attachments dir with attachment' do
-      attachment = Dir["#{location}/*/attachments/non_word_chars_used_01.txt"].first
+      attachment = Dir["#{location}/*/attachments/non_word_chars_used_01-02.txt"].first
       expect(File.exists?(attachment)).to be_true
     end
 
     it 'saves attachment name' do
       plain = File.read(Dir["#{location}/*/plain.html"].first)
-      expect(plain).to include('non_word_chars_used_01.txt')
+      expect(plain).to include('non_word_chars_used_01-02.txt')
     end
   end
 


### PR DESCRIPTION
Underscore and hyphen are both valid characters for a file name. Changing hyphens to underscore caused a good deal of confusion when `letter_opener` renamed the downloaded file. It makes good sense to strip other problematic characters, but we had an attachment with a simple and valid name, and it was being renamed. Our confusion was furthered by `-` becoming `_` as we assumed it was a fat-finger error in our code.

This PR allows those two word separator characters (often used in Ruby land) to remain untouched.
