### PR TITLE
Use mine-types < 3 for Ruby 1.9 support

### DIFF
--- a/letter_opener.gemspec
+++ b/letter_opener.gemspec
@@ -13,6 +13,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'launchy', '~> 2.2'
   s.add_development_dependency 'rspec', '~> 2.14.0'
   s.add_development_dependency 'mail', '~> 2.6.0'
+  s.add_development_dependency 'mime-types', '< 3' if RUBY_VERSION < '2.0'
 
   s.rubyforge_project = s.name
   s.required_rubygems_version = ">= 1.3.4"


### PR DESCRIPTION
I fix [build error](https://travis-ci.org/ryanb/letter_opener/jobs/118970454) on CI.

### Why build error is occured?

`mime-types gem` has required Ruby 2.0 or higher from version 3.0.

### Reference

- [3.0 / 2015-11-21](https://github.com/mime-types/ruby-mime-types/blob/master/History.rdoc#30--2015-11-21)