### PR TITLE
Escape inline attachment names the same way they are stored in the attachments directory

### DIFF
--- a/lib/letter_opener/message.rb
+++ b/lib/letter_opener/message.rb
@@ -60,7 +60,7 @@ module LetterOpener
         body = (@part || @mail).decoded
 
         mail.attachments.each do |attachment|
-          body.gsub!(attachment.url, "attachments/#{attachment.filename}")
+          body.gsub!(attachment.url, "attachments/#{attachment.filename.gsub(/[^\w\-_.]/, '_')}")
         end
 
         body

--- a/spec/letter_opener/delivery_method_spec.rb
+++ b/spec/letter_opener/delivery_method_spec.rb
@@ -272,6 +272,12 @@ describe LetterOpener::DeliveryMethod do
           body 'This is <plain> text'
         end
         attachments['non word:chars/used,01-02.txt'] = File.read(__FILE__)
+
+        url = attachments[0].url
+        html_part do
+          content_type 'text/html; charset=UTF-8'
+          body "This is an image: <img src='#{url}'>"
+        end
       end
     end
 
@@ -283,6 +289,12 @@ describe LetterOpener::DeliveryMethod do
     it 'saves attachment name' do
       plain = File.read(Dir["#{location}/*/plain.html"].first)
       expect(plain).to include('non_word_chars_used_01-02.txt')
+    end
+
+    it 'replaces inline attachment names' do
+      text = File.read(Dir["#{location}/*/rich.html"].first)
+      expect(text).to_not include('attachments/non word:chars/used,01-02.txt')
+      expect(text).to include('attachments/non_word_chars_used_01-02.txt')
     end
   end
 


### PR DESCRIPTION
Before this an inline attachment like `sub/dir/pic.jpg` would be stored as `attachments/sub_dir_pic.jpg` but the HTML part still linked to `attachments/sub/dir/pic.jpg` which subsequently led to broken images. Now the correct file name is used.