### PR TITLE
Load mail before check_delivery_params

### DIFF
--- a/lib/letter_opener/delivery_method.rb
+++ b/lib/letter_opener/delivery_method.rb
@@ -1,4 +1,5 @@
 begin
+  require 'mail'
   require 'mail/check_delivery_params'
 rescue LoadError
 end


### PR DESCRIPTION
Requiring `mail/check_delivery_params` before `mail` itself has been required creates an empty top-level constant `Mail` which prevents autoloading `Mail` itself or any of its contents, causing problems like:

```
$ rails console
Loading development environment (Rails 5.0.0.1)
irb> Mail.new
NoMethodError: undefined method `new' for Mail:Module
```

because:

```
irb> defined? Mail
=> "constant"
irb> Mail.methods - Module.instance_methods
=> []
irb> Mail.constants
=> [:CheckDeliveryParams]
```

This happens because letter opener is requiring `mail/check_delivery_params` which defines an empty Mail module. Requiring mail itself fixes this:

```
irb> require "mail"
irb> Mail.new
=> #<Mail::Message:70122492953160, Multipart: false, Headers: >
```

This is the simplest solution: require mail itself before requiring the check delivery params module. But this means that folks including letter_opener in rails during development will now be pre-loading all of the mail gem every time they boot rails. I'll address this in another PR to add autoloading.