### PR TITLE
Autoload ⚡️

### DIFF
--- a/lib/letter_opener.rb
+++ b/lib/letter_opener.rb
@@ -1,9 +1,6 @@
-require "fileutils"
-require "digest/sha1"
-require "cgi"
-require "uri"
-require "launchy"
+module LetterOpener
+  autoload :Message, "letter_opener/message"
+  autoload :DeliveryMethod, "letter_opener/delivery_method"
+end
 
-require "letter_opener/message"
-require "letter_opener/delivery_method"
 require "letter_opener/railtie" if defined?(Rails::Railtie)

--- a/lib/letter_opener/delivery_method.rb
+++ b/lib/letter_opener/delivery_method.rb
@@ -1,4 +1,5 @@
 begin
+  require 'mail'
   require 'mail/check_delivery_params'
 rescue LoadError
 end

--- a/lib/letter_opener/delivery_method.rb
+++ b/lib/letter_opener/delivery_method.rb
@@ -1,6 +1,8 @@
+require "digest/sha1"
+require "launchy"
 begin
-  require 'mail'
-  require 'mail/check_delivery_params'
+  require "mail"
+  require "mail/check_delivery_params"
 rescue LoadError
 end
 

--- a/lib/letter_opener/message.rb
+++ b/lib/letter_opener/message.rb
@@ -1,4 +1,7 @@
+require "cgi"
 require "erb"
+require "fileutils"
+require "uri"
 
 module LetterOpener
   class Message


### PR DESCRIPTION
Prevent loading upstream requirements until they are needed by using native ruby autoload.

Wrapping the interior constants in autoloads and pushing their dependencies down means the loads of those required gems only happens when they are first used, speeding up the initial boot time of projects using Bundler and Rails for example.