### PR TITLE
Added non-ascii support for emails subjects (view)

### DIFF
--- a/lib/letter_opener/message.html.erb
+++ b/lib/letter_opener/message.html.erb
@@ -79,7 +79,7 @@
 
           <% if mail.subject %>
             <dt>Subject:</dt>
-            <dd><strong><%= h mail.subject %></strong></dd>
+            <dd><strong><%= h mail.subject.toutf8 %></strong></dd>
           <% end %>
 
           <dt>Date:</dt>

--- a/lib/letter_opener/message.rb
+++ b/lib/letter_opener/message.rb
@@ -2,6 +2,7 @@ require "cgi"
 require "erb"
 require "fileutils"
 require "uri"
+require 'kconv'
 
 module LetterOpener
   class Message


### PR DESCRIPTION
Email subjects can be encoded to support addidonal characters. This
changes add decoding support to show the subject in UTF-8

Example subject ('ISO-2022-JP' encoded)

Encoded: =?ISO-2022-JP?B?GyRCRnxLXCROPGdCahsoQg==?=
Decoded: 日本の主題