### PR TITLE
Add license to .gemspec

### DIFF
--- a/letter_opener.gemspec
+++ b/letter_opener.gemspec
@@ -6,6 +6,7 @@ Gem::Specification.new do |s|
   s.homepage    = "http://github.com/ryanb/letter_opener"
   s.summary     = "Preview mail in browser instead of sending."
   s.description = "When mail is sent from your application, Letter Opener will open a preview in the browser instead of sending."
+  s.license     = "MIT"
 
   s.files        = Dir["{lib,spec}/**/*", "[A-Z]*"] - ["Gemfile.lock"]
   s.require_path = "lib"


### PR DESCRIPTION
Certain tools (i.e., versioneye.com) depend on this information being present
to help identify the type of license for dependencies.