### PR TITLE
Suppress deprecation warnings

### DIFF
--- a/lib/letter_opener/delivery_method.rb
+++ b/lib/letter_opener/delivery_method.rb
@@ -24,7 +24,7 @@ module LetterOpener
 
       location = File.join(settings[:location], "#{Time.now.to_f.to_s.tr('.', '_')}_#{Digest::SHA1.hexdigest(mail.encoded)[0..6]}")
       messages = Message.rendered_messages(location, mail)
-      Launchy.open("file:///#{URI.parse(URI.escape(messages.first.filepath))}")
+      Launchy.open("file:///#{URI.parse(CGI.escape(messages.first.filepath))}")
     end
   end
 end

--- a/lib/letter_opener/message.rb
+++ b/lib/letter_opener/message.rb
@@ -37,7 +37,7 @@ module LetterOpener
             File.open(path, 'wb') { |f| f.write(attachment.body.raw_source) }
           end
 
-          @attachments << [attachment.filename, "attachments/#{URI.escape(filename)}"]
+          @attachments << [attachment.filename, "attachments/#{CGI.escape(filename)}"]
         end
       end
 

--- a/lib/letter_opener/message.rb
+++ b/lib/letter_opener/message.rb
@@ -33,7 +33,7 @@ module LetterOpener
           filename = attachment_filename(attachment)
           path = File.join(attachments_dir, filename)
 
-          unless File.exists?(path) # true if other parts have already been rendered
+          unless File.exist?(path) # true if other parts have already been rendered
             File.open(path, 'wb') { |f| f.write(attachment.body.raw_source) }
           end
 

--- a/lib/letter_opener/message.rb
+++ b/lib/letter_opener/message.rb
@@ -103,7 +103,7 @@ module LetterOpener
     end
 
     def auto_link(text)
-      text.gsub(URI.regexp(%W[https http])) do |link|
+      text.gsub(URI::Parser.new.make_regexp(%W[https http])) do |link|
         "<a href=\"#{ link }\">#{ link }</a>"
       end
     end

--- a/spec/letter_opener/delivery_method_spec.rb
+++ b/spec/letter_opener/delivery_method_spec.rb
@@ -223,7 +223,7 @@ describe LetterOpener::DeliveryMethod do
 
     it 'creates attachments dir with attachment' do
       attachment = Dir["#{location}/*/attachments/#{File.basename(__FILE__)}"].first
-      expect(File.exists?(attachment)).to be_truthy
+      expect(File.exist?(attachment)).to be_truthy
     end
 
     it 'saves attachment name' do
@@ -251,7 +251,7 @@ describe LetterOpener::DeliveryMethod do
 
     it 'creates attachments dir with attachment' do
       attachment = Dir["#{location}/*/attachments/#{File.basename(__FILE__)}"].first
-      expect(File.exists?(attachment)).to be_truthy
+      expect(File.exist?(attachment)).to be_truthy
     end
 
     it 'replaces inline attachment urls' do
@@ -283,7 +283,7 @@ describe LetterOpener::DeliveryMethod do
 
     it 'creates attachments dir with attachment' do
       attachment = Dir["#{location}/*/attachments/non_word_chars_used_01-02.txt"].first
-      expect(File.exists?(attachment)).to be_truthy
+      expect(File.exist?(attachment)).to be_truthy
     end
 
     it 'saves attachment name' do


### PR DESCRIPTION
This PR suppresses the following warnings.

- `warning: File.exists? is a deprecated name, use File.exist? instead`
- `warning: URI.regexp is obsolete`
- `warning: URI.escape is obsolete`

These warnings were reproduced with `rspec -w spec`.