### PR TITLE
Use default configuration in rendered_messages

### DIFF
--- a/lib/letter_opener.rb
+++ b/lib/letter_opener.rb
@@ -4,7 +4,7 @@ module LetterOpener
   autoload :Configuration, "letter_opener/configuration"
 
   def self.configuration
-    @configration ||= Configuration.new
+    @configuration ||= Configuration.new
   end
 
   def self.configure

--- a/lib/letter_opener/message.rb
+++ b/lib/letter_opener/message.rb
@@ -16,12 +16,17 @@ module LetterOpener
       messages.sort
     end
 
+    ERROR_MSG = '%s or default configuration must be given'.freeze
+
     def initialize(mail, options = {})
       @mail = mail
-      @location = options[:location]
+      @location = options[:location] || LetterOpener.configuration.location
       @part = options[:part]
-      @template = options[:message_template]
+      @template = options[:message_template] || LetterOpener.configuration.message_template
       @attachments = []
+
+      raise ArgumentError, ERROR_MSG % 'options[:location]' unless @location
+      raise ArgumentError, ERROR_MSG % 'options[:message_template]' unless @template
     end
 
     def render

--- a/spec/letter_opener/message_spec.rb
+++ b/spec/letter_opener/message_spec.rb
@@ -201,4 +201,22 @@ describe LetterOpener::Message do
       expect(message.body.encoding.name).to eq('UTF-8')
     end
   end
+
+  describe '.rendered_messages' do
+    it 'uses configured default template if options not given' do
+      allow(LetterOpener.configuration).to receive(:location) { location }
+      messages = described_class.rendered_messages(mail)
+      expect(messages.first.template).not_to be_nil
+    end
+
+    it 'fails if necessary defaults are not provided' do
+      allow(LetterOpener.configuration).to receive(:location) { nil }
+      expect { described_class.rendered_messages(mail) }.to raise_error(ArgumentError)
+    end
+
+    it 'fails if necessary defaults are not provided' do
+      allow(LetterOpener.configuration).to receive(:message_template) { nil }
+      expect { described_class.rendered_messages(mail) }.to raise_error(ArgumentError)
+    end
+  end
 end


### PR DESCRIPTION
After a recent upgrade, we ran into issue https://github.com/ryanb/letter_opener/issues/147 in our app. When calling `.rendered_messages` directly, the default template and location were not being set as expected. With this change, those options are truly optional.