### PR TITLE
fix "undefined method `root'" on standalone with activemodel

### DIFF
--- a/lib/letter_opener/configuration.rb
+++ b/lib/letter_opener/configuration.rb
@@ -3,7 +3,7 @@ module LetterOpener
     attr_accessor :location, :message_template
 
     def initialize
-      @location = Rails.root.join('tmp', 'letter_opener') if defined?(Rails) && Rails.respond_to?(:root) && Rails.root
+      @location = Rails.root.join('tmp', 'letter_opener') if defined?(Rails) && Rails.respond_to?(:root)
       @message_template = 'default'
     end
   end

--- a/lib/letter_opener/configuration.rb
+++ b/lib/letter_opener/configuration.rb
@@ -3,7 +3,7 @@ module LetterOpener
     attr_accessor :location, :message_template
 
     def initialize
-      @location = Rails.root.join('tmp', 'letter_opener') if defined?(Rails)
+      @location = Rails.root.join('tmp', 'letter_opener') if defined?(Rails) && Rails.respond_to?(:root) && Rails.root
       @message_template = 'default'
     end
   end


### PR DESCRIPTION
Hello.

I found a problem for using letter_opener with standalone mode.

My Gemfile is this:
```
gem 'activesupport', '~> 5.1.6'
gem 'actionmailer', '~> 5.1.6'
gem 'letter_opener'
``` 

When mail is sent, this error occurred:
```
vendor/bundle/ruby/2.3.0/gems/letter_opener-1.6.0/lib/letter_opener/configuration.rb:6:in `initialize': undefined method `root' for Rails:Module (NoMethodError)
```