### PR TITLE
Suppress "character class has duplicated range" warning

### DIFF
--- a/lib/letter_opener/message.rb
+++ b/lib/letter_opener/message.rb
@@ -119,7 +119,7 @@ module LetterOpener
     end
 
     def attachment_filename(attachment)
-      attachment.filename.gsub(/[^\w\-_.]/, '_')
+      attachment.filename.gsub(/[^\w\-.]/, '_')
     end
 
     def <=>(other)


### PR DESCRIPTION
This PR suppresses the following warning.

```console
% ruby -v
ruby 2.6.0dev (2018-08-28 trunk 64584) [x86_64-darwin17]
% RUBYOPT='-w' bundle exec rake spec
(snip)

/Users/koic/src/github.com/ryanb/letter_opener/lib/letter_opener/message.rb:122:
warning: character class has duplicated range: /[^\w\-_.]/

Randomized with seed 27541
................................................................

Finished in 0.38731 seconds (files took 0.41962 seconds to load)
64 examples, 0 failures

Randomized with seed 27541
```

`\w` metacharacter includes `_` character. Here is a quote from the API document.

> /\w/ - A word character ([a-zA-Z0-9_])

https://ruby-doc.org/core-2.5.1/Regexp.html#class-Regexp-label-Character+Classes

This PR removes duplicate character.