### PR TITLE
Support sending emails with only the BCC field populated

### DIFF
--- a/lib/letter_opener/delivery_method.rb
+++ b/lib/letter_opener/delivery_method.rb
@@ -26,12 +26,16 @@ module LetterOpener
 
     private
 
+    def mail_missing_bcc?(mail)
+      mail.bcc.nil? || mail.bcc.empty?
+    end
+
     def validate_mail!(mail)
       if !mail.smtp_envelope_from || mail.smtp_envelope_from.empty?
         raise ArgumentError, "SMTP From address may not be blank"
       end
 
-      if !mail.smtp_envelope_to || mail.smtp_envelope_to.empty?
+      if !mail.smtp_envelope_to || (mail.smtp_envelope_to.empty? && mail_missing_bcc?(mail))
         raise ArgumentError, "SMTP To address may not be blank"
       end
     end

--- a/spec/letter_opener/delivery_method_spec.rb
+++ b/spec/letter_opener/delivery_method_spec.rb
@@ -340,6 +340,19 @@ describe LetterOpener::DeliveryMethod do
         end
       }.not_to raise_exception
     end
+
+    it 'does not raise an exception if there is at least one bcc value' do
+      expect(Launchy).to receive(:open)
+
+      expect {
+        Mail.deliver do
+          from     'Foo foo@example.com'
+          bcc      'Bar bar@example.com'
+          reply_to 'No Reply no-reply@example.com'
+          body     'World! http://example.com'
+        end
+      }.not_to raise_exception
+    end
   end
 
   context 'light template' do


### PR DESCRIPTION
I have a situation where I want to send emails but protect all of the sender email addresses, hence BCCing everyone, but I noticed that the validation for this gem currently doesn't support that.

I've added an extra private method the check if the BCC is set and then adapted the smtp_envelope_to check to also take into account whether the BCC is set.

I've also added an additional spec that checks for this condition, and have been using the gem on my personal projects without any problems.

Please let me know how else I can help out or improve this PR.