### PR TITLE
Use the latest Rubies on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 language: ruby
 before_install:
-  - gem update --system # Need for Ruby 2.5.0. https://github.com/travis-ci/travis-ci/issues/8978
   - gem update bundler
 rvm:
   - 2.0.0
   - 2.1.10
-  - 2.2.9
-  - 2.3.6
-  - 2.4.3
-  - 2.5.0
-  - jruby-9.1.15.0
+  - 2.2.10
+  - 2.3.8
+  - 2.4.5
+  - 2.5.3
+  - 2.6.0
+  - jruby-9.2.5.0


### PR DESCRIPTION
These Rubies has been released.

- https://www.ruby-lang.org/en/news/2018/03/28/ruby-2-2-10-released/
- https://www.ruby-lang.org/en/news/2018/10/17/ruby-2-3-8-released/
- https://www.ruby-lang.org/en/news/2018/10/17/ruby-2-4-5-released/
- https://www.ruby-lang.org/en/news/2018/10/18/ruby-2-5-3-released/
- https://www.ruby-lang.org/en/news/2018/12/25/ruby-2-6-0-released/
- https://www.jruby.org/2018/12/06/jruby-9-2-5-0

And This PR removes `gem update --system` from .travis.yml.

RubyGems 3.0.1 requires Ruby 2.3.0 or higher.
https://github.com/rubygems/rubygems/blob/v3.0.1/rubygems-update.gemspec#L32

It prevents the following build error.

```console
$ gem update --system
Updating rubygems-update
Fetching: rubygems-update-3.0.1.gem (100%)
ERROR:  Error installing rubygems-update:
        rubygems-update requires Ruby version >= 2.3.0.
ERROR:  While executing gem ... (NoMethodError)
    undefined method `version' for nil:NilClass
The command "gem update --system" failed and exited with 1 during .
```