### PR TITLE
Add disable_mail_validation option to configuration

### DIFF
--- a/lib/letter_opener/configuration.rb
+++ b/lib/letter_opener/configuration.rb
@@ -1,10 +1,11 @@
 module LetterOpener
   class Configuration
-    attr_accessor :location, :message_template
+    attr_accessor :location, :message_template, :disable_mail_validation
 
     def initialize
       @location = Rails.root.join('tmp', 'letter_opener') if defined?(Rails) && Rails.respond_to?(:root)
       @message_template = 'default'
+      @disable_mail_validation = false
     end
   end
 end

--- a/lib/letter_opener/delivery_method.rb
+++ b/lib/letter_opener/delivery_method.rb
@@ -17,7 +17,7 @@ module LetterOpener
     end
 
     def deliver!(mail)
-      validate_mail!(mail)
+      validate_mail!(mail) unless LetterOpener.configuration.disable_mail_validation
       location = File.join(settings[:location], "#{Time.now.to_f.to_s.tr('.', '_')}_#{Digest::SHA1.hexdigest(mail.encoded)[0..6]}")
 
       messages = Message.rendered_messages(mail, location: location, message_template: settings[:message_template])


### PR DESCRIPTION
Hi!,  

thank you for letter_opener!! :) 

this is a WIP PR, just want to know if this is the right approach.

We have a codebase that is currently using 1.4.1, I was wondering if there was a way to get only the HTML from the mail (without metadata), and found that the latest version already had the option for a "light" template!

However, it also adds validation for the `smtp_envelope_from` and `smtp_envelope_to` values.   Something that the old version was doing in a different way, and it wasn't preventing the email preview, but the latest version does prevent it.  Hence this PR.

Thanks!