### PR TITLE
Add CHANGELOG, bug tracker, source code metadata to gemspec

### DIFF
--- a/letter_opener.gemspec
+++ b/letter_opener.gemspec
@@ -15,6 +15,11 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec', '~> 3.5.0'
   s.add_development_dependency 'mail', '~> 2.6.0'
 
-  s.rubyforge_project = s.name
   s.required_rubygems_version = ">= 1.3.4"
+  
+  if s.respond_to?(:metadata)
+    s.metadata['changelog_uri'] = 'https://github.com/ryanb/letter_opener/blob/master/CHANGELOG.md'
+    s.metadata['source_code_uri'] = 'https://github.com/ryanb/letter_opener/'
+    s.metadata['bug_tracker_uri'] = 'https://github.com/ryanb/letter_opener/issues'
+  end
 end


### PR DESCRIPTION
- This PR adds [RubyGems metadata](https://guides.rubygems.org/specification-reference/#metadata) to make it possible to navigate from RubyGems _directly_ into the CHANGELOG document via the neat link they surface
- Also: remove very defunct rubyforge reference