### PR TITLE
Enhance 'tmp:clear' task to delete 'tmp/letter_opener' files

### DIFF
--- a/lib/letter_opener/railtie.rb
+++ b/lib/letter_opener/railtie.rb
@@ -8,5 +8,9 @@ module LetterOpener
         )
       end
     end
+
+    rake_tasks do
+      load 'letter_opener/tasks/letter_opener.rake'
+    end
   end
 end

--- a/lib/letter_opener/tasks/letter_opener.rake
+++ b/lib/letter_opener/tasks/letter_opener.rake
@@ -1,0 +1,9 @@
+require 'rails/tasks'
+
+namespace :tmp do
+  task :letter_opener do
+    rm_rf Dir["tmp/letter_opener/[^.]*"], verbose: false
+  end
+end
+
+Rake::Task['tmp:clear'].enhance(['tmp:letter_opener'])


### PR DESCRIPTION
When using Rails, `rake tmp:clear` will remove files from `tmp/cache`, `tmp/socket`, etc.
This PR enhances the task by removing files in `tmp/letter_opener` too.