### PR TITLE
Allow launchy = false to prevent letter opener from opening emails

### DIFF
--- a/lib/letter_opener/configuration.rb
+++ b/lib/letter_opener/configuration.rb
@@ -1,10 +1,11 @@
 module LetterOpener
   class Configuration
-    attr_accessor :location, :message_template
+    attr_accessor :location, :message_template, :launchy
 
     def initialize
       @location = Rails.root.join('tmp', 'letter_opener') if defined?(Rails) && Rails.respond_to?(:root)
       @message_template = 'default'
+      @launchy = true
     end
   end
 end

--- a/lib/letter_opener/delivery_method.rb
+++ b/lib/letter_opener/delivery_method.rb
@@ -21,7 +21,9 @@ module LetterOpener
       location = File.join(settings[:location], "#{Time.now.to_f.to_s.tr('.', '_')}_#{Digest::SHA1.hexdigest(mail.encoded)[0..6]}")
 
       messages = Message.rendered_messages(mail, location: location, message_template: settings[:message_template])
-      Launchy.open("file:///#{messages.first.filepath}")
+      if LetterOpener.configuration.launchy
+        Launchy.open("file:///#{messages.first.filepath}")
+      end
     end
 
     private


### PR DESCRIPTION
## Pull Request

### Issue
https://github.com/ryanb/letter_opener/issues/117

### Description

Provide the option to disable the opening of generated emails.

This change is useful during DB seed to prevent hundreds of emails being opened when you have a reasonably sized application with comprehensive seeds that cover common use cases.

This was originally authored by AmpleOrganics, and we have found it very useful, so are creating a PR to merge into main, as there is an outstanding issue that was not resolved.
https://github.com/AmpleOrganics/letter_opener/commit/e5eddd9a418da0ea60b4ba3b04630ac4e64aa088

### PR Type
What kind of change does this PR introduce?

* [x] Feature


### How Has This Been Tested?

* [x] Manual

