### PR TITLE
Fix bug where all japanese characters are converted to underscores in the file name

### DIFF
--- a/lib/letter_opener/message.rb
+++ b/lib/letter_opener/message.rb
@@ -37,7 +37,7 @@ module LetterOpener
         FileUtils.mkdir_p(attachments_dir)
         mail.attachments.each do |attachment|
           filename = attachment_filename(attachment)
-          path = File.join(attachments_dir, filename)
+          path = File.join(attachments_dir, attachment_filepath(attachment))
 
           unless File.exist?(path) # true if other parts have already been rendered
             File.open(path, 'wb') { |f| f.write(attachment.body.raw_source) }
@@ -118,8 +118,17 @@ module LetterOpener
       CGI.escapeHTML(content)
     end
 
-    def attachment_filename(attachment)
+    def attachment_filepath(attachment)
       attachment.filename.gsub(/[^\w\-.]/, '_')
+    end
+
+    def attachment_filename(attachment)
+      filename = attachment.filename
+      if filename.match(/[^\w\-.]/)
+        URI.encode(filename)
+      else
+        filename
+      end
     end
 
     def <=>(other)

--- a/spec/letter_opener/delivery_method_spec.rb
+++ b/spec/letter_opener/delivery_method_spec.rb
@@ -288,13 +288,13 @@ describe LetterOpener::DeliveryMethod do
 
     it 'saves attachment name' do
       plain = File.read(Dir["#{location}/*/plain.html"].first)
-      expect(plain).to include('non_word_chars_used_01-02.txt')
+      expect(plain).to include(CGI.escape(URI.encode('non word:chars/used,01-02.txt')))
     end
 
     it 'replaces inline attachment names' do
       text = File.read(Dir["#{location}/*/rich.html"].first)
       expect(text).to_not include('attachments/non word:chars/used,01-02.txt')
-      expect(text).to include('attachments/non_word_chars_used_01-02.txt')
+      expect(text).to include(URI.encode('attachments/non word:chars/used,01-02.txt'))
     end
   end
 


### PR DESCRIPTION
## before

attachment file name is "候補者_xxxx.csv"

All Japanese characters in file names are converted to underscores like `____xxx.csv`.

![Screenshot from 2020-03-18 13-59-08](https://user-images.githubusercontent.com/14024165/76926838-b4b74100-6920-11ea-8d99-f4e268a94633.png)

## after

Fixed so that Japanese characters in file names are not converted to underscores using urlencode

![Screenshot from 2020-03-18 13-58-31](https://user-images.githubusercontent.com/14024165/76926846-baad2200-6920-11ea-8317-e77d2b5c5130.png)

