### PR TITLE
Update configuration.rb

### DIFF
--- a/lib/letter_opener/configuration.rb
+++ b/lib/letter_opener/configuration.rb
@@ -3,7 +3,7 @@ module LetterOpener
     attr_accessor :location, :message_template
 
     def initialize
-      @location = Rails.root.join('tmp', 'letter_opener') if defined?(Rails) && Rails.respond_to?(:root)
+      @location = Rails.root.join('tmp', 'letter_opener') if defined?(Rails) && Rails.respond_to?(:root) && Rails.root
       @message_template = 'default'
     end
   end


### PR DESCRIPTION
Re-add "extra check" that was removed from previous commit. 
In some ruby project (like ruby on jets project), Rails may exist, Rails may respond_to root, but root may be nil. 
Actually I don't see the point of removing that "extra check" and I think it is best to keep it...