### PR TITLE
GitHub is HTTPS by default

### DIFF
--- a/letter_opener.gemspec
+++ b/letter_opener.gemspec
@@ -3,7 +3,7 @@ Gem::Specification.new do |s|
   s.version     = "1.7.0"
   s.author      = "Ryan Bates"
   s.email       = "ryan@railscasts.com"
-  s.homepage    = "http://github.com/ryanb/letter_opener"
+  s.homepage    = "https://github.com/ryanb/letter_opener"
   s.summary     = "Preview mail in browser instead of sending."
   s.description = "When mail is sent from your application, Letter Opener will open a preview in the browser instead of sending."
   s.license     = "MIT"
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
       'bug_tracker_uri' => 'https://github.com/ryanb/letter_opener/issues',
       'changelog_uri' => 'https://github.com/ryanb/letter_opener/blob/master/CHANGELOG.md',
       'documentation_uri' => 'http://www.rubydoc.info/gems/letter_opener/',
-      'homepage_uri' => 'http://github.com/ryanb/letter_opener',
+      'homepage_uri' => 'https://github.com/ryanb/letter_opener',
       'source_code_uri' => 'https://github.com/ryanb/letter_opener/',
     }
   end


### PR DESCRIPTION
This reduces unnecessary redirection from http://... to https://... when someone visits this gem's homepage via https://rubygems.org/gems/letter_opener or some tools or APIs that use the gem's metadata.