### PR TITLE
Avoid four slashes for `file` protocol

### DIFF
--- a/lib/letter_opener/delivery_method.rb
+++ b/lib/letter_opener/delivery_method.rb
@@ -21,7 +21,10 @@ module LetterOpener
       location = File.join(settings[:location], "#{Time.now.to_f.to_s.tr('.', '_')}_#{Digest::SHA1.hexdigest(mail.encoded)[0..6]}")
 
       messages = Message.rendered_messages(mail, location: location, message_template: settings[:message_template])
-      Launchy.open("file:///#{messages.first.filepath}")
+      filepath = messages.first.filepath
+      protocol = filepath.start_with?('/') ? 'file://' : 'file:///'
+
+      Launchy.open("#{protocol}#{filepath}")
     end
 
     private


### PR DESCRIPTION
To open the HTML rendering of mails, `letter_opener` uses the `file` protocol. It always adds three slashes `///` and then concatenates the file name to it. If the file name starts with a slash as well (unix based systems and using absolute paths), we end up having 4 consecutive slashes.

On some systems (macOS as reported in #180 and - for me - on Linux) this results in invalid file paths and the file cannot be opened.

For me, this happens using `xdg-open` and `qutebrowser` as a browser. The following fails for me (qutebrowser is looking for `file://tmp/test.html`):

```
xdg-open file:////tmp/test.html
```

Both `firefox file:////tmp/test.html` and `qutebrowser file:////tmp/test.html` open the file correctly. So this could also be a problem with `xdg-open`. I don't think that 4 slashes are correct though.

So I would still propose to fix this (fixing it also for the macOS people). But there might be a cleaner solution than my proposal.