### PR TITLE
Add encoded subject to utf8

### DIFF
--- a/lib/letter_opener/message.rb
+++ b/lib/letter_opener/message.rb
@@ -2,6 +2,7 @@ require "cgi"
 require "erb"
 require "fileutils"
 require "uri"
+require "kconv"
 
 module LetterOpener
   class Message
@@ -82,6 +83,10 @@ module LetterOpener
 
     def sender
       @sender ||= Array(@mail['sender']).join(", ")
+    end
+
+    def subject
+      @subject ||= @mail.subject.toutf8
     end
 
     def to

--- a/spec/letter_opener/message_spec.rb
+++ b/spec/letter_opener/message_spec.rb
@@ -35,6 +35,20 @@ describe LetterOpener::Message do
 
   end
 
+  describe '#subject' do
+    it 'handles UTF-8 charset subject' do
+      mail = mail(:subject => 'test_mail')
+      message = described_class.new(mail, location: location)
+      expect(message.subject).to eq('test_mail')
+    end
+
+    it 'handles encode ISO-2022-JP charset subject' do
+      mail = mail(:subject => '=?iso-2022-jp?B?GyRCJUYlOSVIJWEhPCVrGyhC?=')
+      message = described_class.new(mail, location: location)
+      expect(message.subject).to eq('テストメール')
+    end
+  end
+
   describe '#to' do
     it 'handles one email as a string' do
       mail   = mail(:to => 'test@example.com')


### PR DESCRIPTION
Converts the mail title to UTF8.
With this change added, Japanese titles will be displayed correctly.

Example: Encoding of ISO-2022-JP

Encoded: =?ISO-2022-JP?B?GyRCJDMkcyRLJEEkTxso?=?
Decoded: こんにちは