### PR TITLE
Allow configuration of the 'file///' part in Launchy.open path

### DIFF
--- a/lib/letter_opener/configuration.rb
+++ b/lib/letter_opener/configuration.rb
@@ -1,10 +1,11 @@
 module LetterOpener
   class Configuration
-    attr_accessor :location, :message_template
+    attr_accessor :location, :message_template, :files_storage
 
     def initialize
       @location = Rails.root.join('tmp', 'letter_opener') if defined?(Rails) && Rails.respond_to?(:root) && Rails.root
       @message_template = 'default'
+      @files_storage = 'file:///'
     end
   end
 end

--- a/lib/letter_opener/delivery_method.rb
+++ b/lib/letter_opener/delivery_method.rb
@@ -10,6 +10,7 @@ module LetterOpener
     def initialize(options = {})
       options[:message_template] ||= LetterOpener.configuration.message_template
       options[:location] ||= LetterOpener.configuration.location
+      options[:files_storage] ||= LetterOpener.configuration.files_storage
 
       raise InvalidOption, "A location option is required when using the Letter Opener delivery method" if options[:location].nil?
 
@@ -21,7 +22,7 @@ module LetterOpener
       location = File.join(settings[:location], "#{Time.now.to_f.to_s.tr('.', '_')}_#{Digest::SHA1.hexdigest(mail.encoded)[0..6]}")
 
       messages = Message.rendered_messages(mail, location: location, message_template: settings[:message_template])
-      Launchy.open("file:///#{messages.first.filepath}")
+      Launchy.open("#{settings[:files_storage]}#{messages.first.filepath}")
     end
 
     private


### PR DESCRIPTION
Hello, 

I would like to be able to modify the 'file:///' part in the Launchy.open path. 
Indeed, I'm actually using WSL 2 and letter opener - as is - doesn't work because the absolute path is /home/... but WSL 2 is a VM. Its files are accessible on the "local network" of the computer using //wsl$/VM-distrib. 

I just need to replace 'file:///' with 'file://///wsl$/Ubuntu-18.04'

As I think WSL 2 may not be the only environment where someone can have that problem, I was thinking I could do a little PR to be able to modify that "file:///" directly from Letter opener configurations. 

But... I don't know if you are interested in that PR.
And if you do, where should I put the unit tests to test that new configuration actually works?

Or would you think of any better way to make letter opener works within that specific environment?

Thanks a lot for your guidance!