### PR TITLE
Suppress ERB warning when running RSpec

### DIFF
--- a/letter_opener.gemspec
+++ b/letter_opener.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.require_path = "lib"
 
   s.add_dependency 'launchy', '>= 2.2', '< 5'
-  s.add_development_dependency 'rspec', '~> 3.5.0'
+  s.add_development_dependency 'rspec', '~> 3.10.0'
   s.add_development_dependency 'mail', '~> 2.6.0'
 
   s.required_rubygems_version = ">= 1.3.4"


### PR DESCRIPTION
This PR bumps RSpec to 3.10 to suppress ERB warning when running RSpec.

```console
% ruby -v
ruby 3.1.0dev (2021-09-20T13:01:58Z master 9770bf23b7) [x86_64-darwin19]
% cd path/to/letter_opener
% bundle update
% bundle exec rake
/Users/koic/.rbenv/versions/3.1.0-dev/lib/ruby/gems/3.1.0/gems/rspec-core-3.5.4/lib/rspec/core/configuration_options.rb:171:
warning: Passing safe_level with the 2nd argument of ERB.new is deprecated.
Do not use it, and specify other arguments as keyword arguments.
/Users/koic/.rbenv/versions/3.1.0-dev/lib/ruby/gems/3.1.0/gems/rspec-core-3.5.4/lib/rspec/core/configuration_options.rb:171:
warning: Passing trim_mode with the 3rd argument of ERB.new is deprecated.
Use keyword argument like ERB.new(str, trim_mode: ...) instead.

Randomized with seed 45327
................................................................

Finished in 0.34506 seconds (files took 0.36652 seconds to load)
64 examples, 0 failures

Randomized with seed 45327
```