### PR TITLE
Add Ruby 3.1 to the CI matrix

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -18,15 +18,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.6', '2.7', '3.0', 'truffleruby', 'jruby']
+        ruby-version: ['2.6', '2.7', '3.0', '3.1', 'truffleruby', 'jruby']
 
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby
     # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
     # change this to (see https://github.com/ruby/setup-ruby#versioning):
-    # uses: ruby/setup-ruby@v1
-      uses: ruby/setup-ruby@473e4d8fe5dd94ee328fdfca9f8c9c7afc9dae5e
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,10 @@
 source "https://rubygems.org"
 gemspec
 
+if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3.1")
+  gem "net-imap", require: false
+  gem "net-pop", require: false
+  gem "net-smtp", require: false
+end
+
 gem "rake"


### PR DESCRIPTION
This PR adds Ruby 3.1 to the CI matrix.  As part of that process it:

1. Updates the version of `ruby/setup-ruby` to 1, so we pick up Ruby 3.1 (and future updates)
2. Conditionally adds the `net-imap`, `net-pop`, and `net-smtp` gems to the Gemfile for Ruby 3.1 and up (for which these gems are no longer automatically included).