### PR TITLE
Fix duplication of Rails tasks

### DIFF
--- a/lib/letter_opener/tasks/letter_opener.rake
+++ b/lib/letter_opener/tasks/letter_opener.rake
@@ -1,9 +1,7 @@
-require 'rails/tasks'
-
 namespace :tmp do
   task :letter_opener do
     rm_rf Dir["tmp/letter_opener/[^.]*"], verbose: false
   end
-end
 
-Rake::Task['tmp:clear'].enhance(['tmp:letter_opener'])
+  task clear: :letter_opener
+end


### PR DESCRIPTION
The `rails middleware` task lists all middleware twice when using letter_opener 1.8.0.

I believe this might be caused by the Rails tasks being loaded twice, the extra loading of which is triggered by the use of `require 'rails/tasks'` in `letter_opener.rake`. Whether that's the correct explanation, removing that `require` resolves the issue.

This PR reworks the task setup to avoid needing the excess `require` while still chaining to `tmp:clear`.

Confirmed on Rails 7.0.2.x, but guessing it happens on earlier versions as well.