### PR TITLE
Optionally decode attachment contents

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,3 +8,4 @@ if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3.1")
 end
 
 gem "rake"
+gem "pry"

--- a/Gemfile
+++ b/Gemfile
@@ -8,4 +8,3 @@ if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3.1")
 end
 
 gem "rake"
-gem "pry"

--- a/lib/letter_opener/configuration.rb
+++ b/lib/letter_opener/configuration.rb
@@ -1,11 +1,12 @@
 module LetterOpener
   class Configuration
-    attr_accessor :location, :message_template, :file_uri_scheme
+    attr_accessor :location, :message_template, :file_uri_scheme, :decode_attachments
 
     def initialize
       @location = Rails.root.join('tmp', 'letter_opener') if defined?(Rails) && Rails.respond_to?(:root) && Rails.root
       @message_template = 'default'
       @file_uri_scheme = nil
+      @decode_attachments = false
     end
   end
 end

--- a/lib/letter_opener/message.rb
+++ b/lib/letter_opener/message.rb
@@ -24,6 +24,7 @@ module LetterOpener
       @location = options[:location] || LetterOpener.configuration.location
       @part = options[:part]
       @template = options[:message_template] || LetterOpener.configuration.message_template
+      @decode_attachments = options[:decode_attachments] || LetterOpener.configuration.decode_attachments
       @attachments = []
 
       raise ArgumentError, ERROR_MSG % 'options[:location]' unless @location
@@ -41,7 +42,8 @@ module LetterOpener
           path = File.join(attachments_dir, filename)
 
           unless File.exist?(path) # true if other parts have already been rendered
-            File.open(path, 'wb') { |f| f.write(attachment.body.raw_source) }
+            content = @decode_attachments ? attachment.decoded : attachment.body.raw_source
+            File.open(path, 'wb') { |f| f.write(content) }
           end
 
           @attachments << [attachment.filename, "attachments/#{filename}"]

--- a/lib/letter_opener/message.rb
+++ b/lib/letter_opener/message.rb
@@ -24,7 +24,7 @@ module LetterOpener
       @location = options[:location] || LetterOpener.configuration.location
       @part = options[:part]
       @template = options[:message_template] || LetterOpener.configuration.message_template
-      @decode_attachments = options[:decode_attachments] || LetterOpener.configuration.decode_attachments
+      @decode_attachments = LetterOpener.configuration.decode_attachments
       @attachments = []
 
       raise ArgumentError, ERROR_MSG % 'options[:location]' unless @location

--- a/spec/letter_opener/delivery_method_spec.rb
+++ b/spec/letter_opener/delivery_method_spec.rb
@@ -332,7 +332,7 @@ describe LetterOpener::DeliveryMethod do
         content = 'abc'
         deliver_encoded(content)
         text = File.read(Dir["#{location}/*/attachments/encoded_text.txt"].first)
-        expect(text).to include('abc')
+        expect(text).to include(content)
 
         LetterOpener.configure do |config|
           config.decode_attachments = false


### PR DESCRIPTION
Hello, I was recently appending an attachment the following way:
```
attachments["report.xlsx"] = {
  mime_type: Mime[:xlsx],
  encoding: "base64",
  content: Base64.encode64(raw_xlsx)
}
```
and I realized the gem's default behavior is to write encoded attachments to file.
There is a small issue with that though: downloading and trying to open the attachment may fail because the handling application may not be able to read the Base64-encoded file.
I thought it would be nice to be able to optionally write the attachment _decoded_.

Sorry for not creating an issue, I thought the shortest route to start the discussion would be to present the proposed changes.
Thank you.

Related:
https://github.com/ryanb/letter_opener/issues/49
https://github.com/ryanb/letter_opener/issues/7