### PR TITLE
Exposing Letter Opener File Save Path

### DIFF
--- a/lib/letter_opener/message.rb
+++ b/lib/letter_opener/message.rb
@@ -51,6 +51,8 @@ module LetterOpener
       File.open(filepath, 'w') do |f|
         f.write ERB.new(template).result(binding)
       end
+
+      mail["location_#{type}"] = filepath
     end
 
     def template

--- a/spec/letter_opener/message_spec.rb
+++ b/spec/letter_opener/message_spec.rb
@@ -216,6 +216,23 @@ describe LetterOpener::Message do
     end
   end
 
+  describe '#render' do
+    it 'records the saved email path for plain content type' do
+      mail = mail(:subject => 'test_mail')
+      message = described_class.new(mail, location: location)
+      message.render
+      expect(mail['location_plain'].value).to end_with('tmp/letter_opener/plain.html')
+    end
+
+
+    it 'records the saved email path for rich content type' do
+      mail = mail(:content_type => 'text/html', :subject => 'test_mail')
+      message = described_class.new(mail, location: location)
+      message.render
+      expect(mail['location_rich'].value).to end_with('tmp/letter_opener/rich.html')
+    end
+  end
+
   describe '.rendered_messages' do
     it 'uses configured default template if options not given' do
       allow(LetterOpener.configuration).to receive(:location) { location }


### PR DESCRIPTION
I was interested in knowing where the generated message was being located so that I can open it up in another application. This PR simply exposes the generated message path in the original Mail::Message object. Thought someone else might find this useful.

It exposes the rich and the plain version at:

```
mail['location-rich'].value
=> "/app/tmp/letter_opener/1700503091_0311892_1d5f48e/rich.html"
mail['location-plain'].value
=> "/app/tmp/letter_opener/1700503091_0311892_1d5f48e/plain.html"
```

This object is returned from mailers such as ActiveMailer after the mail is sent.