### PR TITLE
Fix Ruby 3.3 bundled gem warning

### DIFF
--- a/letter_opener.gemspec
+++ b/letter_opener.gemspec
@@ -12,6 +12,7 @@ Gem::Specification.new do |s|
   s.require_path = "lib"
 
   s.add_dependency 'launchy', '>= 2.2', '< 3'
+  s.add_dependency 'nkf'
 
   s.add_development_dependency 'rspec', '~> 3.10.0'
   s.add_development_dependency 'mail', '~> 2.6.0'


### PR DESCRIPTION
[Ruby 3.3 has been released.](https://www.ruby-lang.org/en/news/2023/12/25/ruby-3-3-0-released/) In Ruby 3.3, the `nkf` gem has [become a bundled gem](https://www.ruby-lang.org/en/news/2023/12/25/ruby-3-3-0-released/), and it generates the following warning. To avoid this, I have added the `nkf` gem to the `letter_opener.gemspec`.

## Before
```sh
~/work/letter_opener master
❯ ruby -v
ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [x86_64-darwin23]

~/work/letter_opener master
❯ bundle exec rake
/Users/m_nakamura145/work/letter_opener/lib/letter_opener/message.rb:5: warning: kconv is found in nkf, which will no longer be part of the default gems since Ruby 3.4.0. Add nkf to your Gemfile or gemspec.

Randomized with seed 23448
....................................................................

Finished in 0.21931 seconds (files took 0.2301 seconds to load)
68 examples, 0 failures

Randomized with seed 23448
```

## After

```sh
~/work/letter_opener master*
❯ bundle exec rake

Randomized with seed 31635
....................................................................

Finished in 0.22516 seconds (files took 0.2494 seconds to load)
68 examples, 0 failures

Randomized with seed 31635
```