### PR TITLE
Bump actions/checkout

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -21,7 +21,7 @@ jobs:
         ruby-version: ['3.0', '3.1', '3.2', '3.3', 'truffleruby', 'jruby']
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Ruby
     # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
     # change this to (see https://github.com/ruby/setup-ruby#versioning):


### PR DESCRIPTION
GitHub is [planning to upgrade to Node 20](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/). Versions prior to actions/checkout v3 use an outdated version of node, so we will upgrade to actions/checkout v4, where [Node 20 is the default](https://github.com/actions/checkout/releases/tag/v4.0.0).