### PR TITLE
Add raw template to show headers and content for debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ LetterOpener.configure do |config|
   # Default value is `:default` that renders styled message with showing useful metadata.
   config.message_template = :light
 
+  # For debugging you can render the raw message source using the `:raw` template.
+  # config.message_template = :raw
+
   # To change default file URI scheme you can provide `file_uri_scheme` config.
   # It might be useful when you use WSL (Windows Subsystem for Linux) and default
   # scheme doesn't work for you.

--- a/lib/letter_opener/templates/raw.html.erb
+++ b/lib/letter_opener/templates/raw.html.erb
@@ -1,0 +1,119 @@
+<html>
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=<%= encoding %>">
+    <% if mail.subject %>
+      <title><%= h mail.subject %></title>
+    <% end %>
+
+    <style type="text/css">
+      #container {
+        margin: 10px auto;
+      }
+      #message_headers {
+        background: #fff;
+        font-size: 12px;
+        font-family: "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+        border-bottom: 1px solid #dedede;
+        margin-bottom: 10px;
+        overflow: auto;
+      }
+
+      #message_headers dl {
+        float: left;
+        line-height: 1.3em;
+        padding: 0;
+      }
+
+      #message_headers dt {
+        width: 92px;
+        margin: 0;
+        float: left;
+        text-align: right;
+        font-weight: bold;
+        color: #7f7f7f;
+      }
+
+      #message_headers dd {
+        margin: 0 0 0 102px;
+      }
+
+      #message_headers p.alternate {
+        float: right;
+        margin: 0;
+      }
+
+      #message_headers p.alternate a {
+        color: #09c;
+      }
+
+      pre#message_body {
+        padding: 4px;
+        white-space: pre-wrap;
+        border: 1px solid #eee;
+        background-color: #fcfcfc;
+      }
+
+      iframe {
+        border: 0;
+        width: 100%;
+        height: 100%;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="container">
+      <div id="message_headers">
+        <dl>
+          <dt>From:</dt>
+          <dd><%= h from %></dd>
+
+          <% unless sender.empty? %>
+            <dt>Sender:</dt>
+            <dd><%= h sender %></dd>
+          <% end %>
+
+          <% unless reply_to.empty? %>
+            <dt>Reply-To:</dt>
+            <dd><%= h reply_to %></dd>
+          <% end %>
+
+          <% if mail.subject %>
+            <dt>Subject:</dt>
+            <dd><strong><%= h mail.subject %></strong></dd>
+          <% end %>
+
+          <dt>Date:</dt>
+          <dd><%= Time.now.strftime("%b %e, %Y %I:%M:%S %p %Z") %></dd>
+
+          <% unless to.empty? %>
+            <dt>To:</dt>
+            <dd><%= h to %></dd>
+          <% end %>
+
+          <% unless cc.empty? %>
+            <dt>CC:</dt>
+            <dd><%= h cc %></dd>
+          <% end %>
+
+          <% unless bcc.empty? %>
+            <dt>BCC:</dt>
+            <dd><%= h bcc %></dd>
+          <% end %>
+
+          <% if @attachments.any? %>
+            <dt>Attachments:</dt>
+            <dd>
+            <% @attachments.each do |filename, path| %>
+              <a href="<%= path %>"><%= filename %></a>&nbsp;
+            <% end %>
+            </dd>
+          <% end %>
+        </dl>
+      </div>
+
+      <pre>
+        <%= h(mail.to_s) %>
+      </pre>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
## Why was this PR created

In some cases, it is useful to be able to see the raw message including all headers. This is useful in debugging headers and/or body content.

This resolves #218 

## What is included in this PR

`raw.html.erb` includes all the parsed content of the default template but also displays the raw content of the email body.